### PR TITLE
Fix rafter deployment issue

### DIFF
--- a/pkg/reconciler/instances/rafter/action.go
+++ b/pkg/reconciler/instances/rafter/action.go
@@ -25,8 +25,8 @@ const (
 	accessKeySize            = 20
 	secretKeySize            = 40
 
-	accessKeyName = "accessKey"
-	secretKeyName = "secretKey"
+	accessKeyName = "accesskey"
+	secretKeyName = "secretkey"
 )
 
 type CustomAction struct {


### PR DESCRIPTION
Fix key names in the `rafter-minio` secret to be compatible with the `rafter` deployment.