### PR TITLE
Set InstallCRD flag the first scheduled component automatically

### DIFF
--- a/pkg/scheduler/localscheduler.go
+++ b/pkg/scheduler/localscheduler.go
@@ -4,14 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/kyma-incubator/reconciler/pkg/reconciler"
-
 	"github.com/google/uuid"
 	"github.com/kyma-incubator/reconciler/pkg/cluster"
 	"github.com/kyma-incubator/reconciler/pkg/keb"
 	"github.com/kyma-incubator/reconciler/pkg/model"
+	"github.com/kyma-incubator/reconciler/pkg/reconciler"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
+	"sync/atomic"
 )
 
 type LocalSchedulerOption func(*LocalScheduler)
@@ -22,15 +22,9 @@ func WithLogger(logger *zap.SugaredLogger) LocalSchedulerOption {
 	}
 }
 
-func WithCRDComponents(components ...string) LocalSchedulerOption {
-	return func(ls *LocalScheduler) {
-		ls.crdComponents = components
-	}
-}
-
 func WithPrerequisites(components ...string) LocalSchedulerOption {
 	return func(ls *LocalScheduler) {
-		ls.prereqs = components
+		ls.prerequisites = components
 	}
 }
 
@@ -42,10 +36,10 @@ func WithStatusFunc(statusFunc ReconcilerStatusFunc) LocalSchedulerOption {
 
 type LocalScheduler struct {
 	logger        *zap.SugaredLogger
-	crdComponents []string
-	prereqs       []string
+	prerequisites []string
 	statusFunc    ReconcilerStatusFunc
 	workerFactory WorkerFactory
+	installedCRD  int32
 }
 
 func NewLocalScheduler(opts ...LocalSchedulerOption) *LocalScheduler {
@@ -75,12 +69,7 @@ func (ls *LocalScheduler) Run(ctx context.Context, c *keb.Cluster) error {
 		return fmt.Errorf("failed to get components: %s", err)
 	}
 
-	err = ls.reconcileCRDComponents(components, clusterState, schedulingID)
-	if err != nil {
-		return fmt.Errorf("failed to reconcile CRD component: %s", err)
-	}
-
-	err = ls.reconcilePrereqs(components, clusterState, schedulingID)
+	err = ls.reconcilePrerequisites(components, clusterState, schedulingID)
 	if err != nil {
 		return fmt.Errorf("failed to reconcile prerequisite component: %s", err)
 	}
@@ -138,27 +127,13 @@ func toLocalClusterState(c *keb.Cluster) (*cluster.State, error) {
 	}, nil
 }
 
-func (ls *LocalScheduler) reconcileCRDComponents(components []*keb.Component, clusterState *cluster.State, schedulingID string) error {
+func (ls *LocalScheduler) reconcilePrerequisites(components []*keb.Component, clusterState *cluster.State, schedulingID string) error {
 	for _, c := range components {
-		if !ls.isCRDComponent(c) {
+		if !ls.isPrerequisite(c) {
 			continue
 		}
 
-		err := ls.reconcile(c, clusterState, schedulingID, true)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (ls *LocalScheduler) reconcilePrereqs(components []*keb.Component, clusterState *cluster.State, schedulingID string) error {
-	for _, c := range components {
-		if !ls.isPrereq(c) || ls.isCRDComponent(c) {
-			continue
-		}
-
-		err := ls.reconcile(c, clusterState, schedulingID, false)
+		err := ls.reconcile(c, clusterState, schedulingID)
 		if err != nil {
 			return err
 		}
@@ -169,33 +144,31 @@ func (ls *LocalScheduler) reconcilePrereqs(components []*keb.Component, clusterS
 func (ls *LocalScheduler) reconcileUnprioritizedComponents(ctx context.Context, components []*keb.Component, clusterState *cluster.State, schedulingID string) error {
 	g, _ := errgroup.WithContext(ctx)
 	for _, c := range components {
-		if ls.isPrereq(c) || ls.isCRDComponent(c) {
+		if ls.isPrerequisite(c) {
 			continue
 		}
 
 		component := c // https://golang.org/doc/faq#closures_and_goroutines
 		g.Go(func() error {
-			return ls.reconcile(component, clusterState, schedulingID, true)
+			return ls.reconcile(component, clusterState, schedulingID)
 		})
 	}
 
 	return g.Wait()
 }
 
-func (ls *LocalScheduler) isPrereq(c *keb.Component) bool {
-	return contains(ls.prereqs, c.Component)
+func (ls *LocalScheduler) isPrerequisite(c *keb.Component) bool {
+	return contains(ls.prerequisites, c.Component)
 }
 
-func (ls *LocalScheduler) isCRDComponent(c *keb.Component) bool {
-	return contains(ls.crdComponents, c.Component)
-}
-
-func (ls *LocalScheduler) reconcile(component *keb.Component, state *cluster.State, schedulingID string, installCRD bool) error {
+func (ls *LocalScheduler) reconcile(component *keb.Component, state *cluster.State, schedulingID string) error {
 	worker, err := ls.workerFactory.ForComponent(component.Component)
 	if err != nil {
 		return fmt.Errorf("failed to create a worker: %s", err)
 	}
 
+	// make sure that installCRD will be only set to true when the first component is scheduled for reconciliation
+	installCRD := atomic.CompareAndSwapInt32(&ls.installedCRD, 0, 1)
 	err = worker.Reconcile(component, *state, schedulingID, installCRD)
 	if err != nil {
 		return fmt.Errorf("failed to reconcile a component: %s", component.Component)

--- a/pkg/scheduler/localscheduler_test.go
+++ b/pkg/scheduler/localscheduler_test.go
@@ -59,13 +59,13 @@ func TestLocalSchedulerOrder(t *testing.T) {
 		expectedOrder []string
 	}{
 		{
-			summary:       "single prerequisite",
+			summary:       "single prereq",
 			prerequisites: []string{"b"},
 			allComponents: []string{"a", "b"},
 			expectedOrder: []string{"b", "a"},
 		},
 		{
-			summary:       "multiple prerequisites",
+			summary:       "multiple prereqs",
 			prerequisites: []string{"b", "d"},
 			allComponents: []string{"d", "a", "b"},
 			expectedOrder: []string{"d", "b", "a"},
@@ -100,7 +100,7 @@ func TestLocalSchedulerOrder(t *testing.T) {
 
 			sut := LocalScheduler{
 				logger:        zap.NewNop().Sugar(),
-				prerequisites: tc.prerequisites,
+				prereqs:       tc.prerequisites,
 				workerFactory: workerFactoryMock,
 			}
 

--- a/resources/reconciler/values.yaml
+++ b/resources/reconciler/values.yaml
@@ -14,7 +14,7 @@ global:
   image:
     repository: eu.gcr.io/kyma-project/incubator/reconciler
     pullPolicy: IfNotPresent
-    tag: PR-144
+    tag: 2fd3699a
   components: []
 
 # TODO https://github.com/kyma-incubator/reconciler/issues/53


### PR DESCRIPTION
* Previously it was allowed for the callers of `LocalScheduler` to choose for which components the` installCRD` flag is supposed to be set. This PR simplifies the API by automatically setting `installCRD` for the first component (in a thread-safe way).