### PR TITLE
Add compiler flags to reduce binary size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN mkdir /user && \
 WORKDIR $SRC_DIR
 
 COPY configs /configs
-RUN CGO_ENABLED=0 go build -o /bin/reconciler ./cmd/main.go
+RUN CGO_ENABLED=0 go build -o /bin/reconciler -ldflags '-s -w' ./cmd/main.go
 
 RUN apk update && apk upgrade && \
     apk --no-cache add curl

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ ifeq ($(VERSION),stable)
 endif
 
 .DEFAULT_GOAL=all
+FLAGS = -ldflags '-s -w'
 
 .PHONY: resolve
 resolve:

--- a/pkg/server/error.go
+++ b/pkg/server/error.go
@@ -2,15 +2,29 @@ package server
 
 import (
 	"encoding/json"
-	"fmt"
+	"github.com/kyma-incubator/reconciler/pkg/logger"
+	"github.com/pkg/errors"
 	"net/http"
 )
 
 func SendHTTPError(w http.ResponseWriter, httpCode int, resp interface{}) {
-	w.WriteHeader(httpCode)
-	w.Header().Set("content-type", "application/json")
-	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		http.Error(w, fmt.Sprintf("Failed to encode response payload to JSON: %s", err), http.StatusInternalServerError)
+	log := logger.NewLogger(false)
+
+	payload, err := json.Marshal(resp)
+	if err != nil {
+		err = errors.Wrap(err, "failed to encode HTTP error response to JSON")
+	} else {
+		w.WriteHeader(httpCode)
+		w.Header().Set("content-type", "application/json")
+		if _, err = w.Write(payload); err == nil {
+			log.Warnf("Sending HTTP error response (httpCode %d): %s", httpCode, payload)
+			return
+		}
+		err = errors.Wrap(err, "failed to write error payload to HTTP response writer")
 	}
+
+	log.Errorf("Failed to process HTTP error response (fallback to %d - internal server error): %v",
+		http.StatusInternalServerError, err)
+	w.WriteHeader(http.StatusInternalServerError)
+	http.Error(w, err.Error(), http.StatusInternalServerError)
 }


### PR DESCRIPTION
Add compiler flags to strip debugging DWARF tables from the CLI binary.
This reduces the size of the binary by ~20%

**More info**
https://golang.org/cmd/link/