### PR TITLE
Tests Correction

### DIFF
--- a/pkg/reconciler/service/runner_test.go
+++ b/pkg/reconciler/service/runner_test.go
@@ -328,7 +328,7 @@ func newCleanupFunc(t *testing.T) func(bool) {
 		//remove all installed components
 		cleanup.RemoveKymaComponent(t, kymaVersion, clusterUsersComponent, "default")
 		cleanup.RemoveKymaComponent(t, kymaVersion, apiGatewayComponent, "default")
-		cleanup.RemoveKymaComponent(t, fakeKymaVersion, fakeComponent, "unittest-service")
+		cleanup.RemoveKymaComponent(t, fakeKymaVersion, fakeComponent, "default")
 		//remove the cloned workspace
 		if deleteWorkspace {
 			wsf, err := ws.NewFactory(nil, "./test", logger.NewLogger(true))


### PR DESCRIPTION
Fix for tests failing with the following message:
```
 test.go:45: 
        	Error Trace:	test.go:45
        	            				runner_test.go:331
        	            				runner_test.go:68
        	Error:      	Received unexpected error:
        	            	namespaces "unittest-service" not found
        	Test:       	TestRunner
```