### PR TITLE
Include component resources to be installed with chart

### DIFF
--- a/pkg/reconciler/instances/istio/action_test.go
+++ b/pkg/reconciler/instances/istio/action_test.go
@@ -1,0 +1,70 @@
+package istio
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+const (
+	istioManifest = `---
+apiVersion: version/v1
+kind: Kind1
+metadata:
+  namespace: namespace
+  name: name
+---
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  namespace: namespace
+  name: name
+---
+apiVersion: version/v2
+kind: Kind2
+metadata:
+  namespace: namespace
+  name: name
+`
+
+	istioManifestWithoutIstioOperator = `---
+apiVersion: version/v1
+kind: Kind1
+metadata:
+  namespace: namespace
+  name: name
+---
+apiVersion: version/v2
+kind: Kind2
+metadata:
+  namespace: namespace
+  name: name
+`
+)
+
+func Test_generateNewManifestWithoutIstioOperatorFrom(t *testing.T) {
+
+	t.Run("should generate empty manifest from empty input manifest", func(t *testing.T) {
+		// when
+		result := generateNewManifestWithoutIstioOperatorFrom("")
+
+		// then
+		require.Empty(t, result)
+	})
+
+	t.Run("should return manifest without IstioOperator kind if it was not present ", func(t *testing.T) {
+		// when
+		result := generateNewManifestWithoutIstioOperatorFrom(istioManifestWithoutIstioOperator)
+
+		// then
+		require.Equal(t, result, istioManifestWithoutIstioOperator)
+	})
+
+	t.Run("should return manifest without IstioOperator kind if it was present", func(t *testing.T) {
+		// when
+		result := generateNewManifestWithoutIstioOperatorFrom(istioManifest)
+
+		// then
+		require.Equal(t, result, istioManifestWithoutIstioOperator)
+	})
+
+}

--- a/pkg/reconciler/instances/istio/action_test.go
+++ b/pkg/reconciler/instances/istio/action_test.go
@@ -1,7 +1,6 @@
 package istio
 
 import (
-	"fmt"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
@@ -46,9 +45,10 @@ func Test_generateNewManifestWithoutIstioOperatorFrom(t *testing.T) {
 
 	t.Run("should generate empty manifest from empty input manifest", func(t *testing.T) {
 		// when
-		result := generateNewManifestWithoutIstioOperatorFrom("")
+		result, err := generateNewManifestWithoutIstioOperatorFrom("")
 
 		// then
+		require.NoError(t, err)
 		require.Empty(t, result)
 	})
 
@@ -59,9 +59,10 @@ func Test_generateNewManifestWithoutIstioOperatorFrom(t *testing.T) {
 		require.NotContains(t, istioManifestWithoutIstioOperator, "IstioOperator")
 
 		// when
-		result := generateNewManifestWithoutIstioOperatorFrom(istioManifestWithoutIstioOperator)
+		result, err := generateNewManifestWithoutIstioOperatorFrom(istioManifestWithoutIstioOperator)
 
 		// then
+		require.NoError(t, err)
 		require.Contains(t, result, "Kind1")
 		require.Contains(t, result, "Kind2")
 		require.NotContains(t, result, "IstioOperator")
@@ -74,10 +75,10 @@ func Test_generateNewManifestWithoutIstioOperatorFrom(t *testing.T) {
 		require.Contains(t, istioManifest, "IstioOperator")
 
 		// when
-		result := generateNewManifestWithoutIstioOperatorFrom(istioManifest)
-		fmt.Println(result)
+		result, err := generateNewManifestWithoutIstioOperatorFrom(istioManifest)
 
 		// then
+		require.NoError(t, err)
 		require.Contains(t, result, "Kind1")
 		require.Contains(t, result, "Kind2")
 		require.NotContains(t, result, "IstioOperator")

--- a/pkg/reconciler/instances/istio/action_test.go
+++ b/pkg/reconciler/instances/istio/action_test.go
@@ -1,6 +1,7 @@
 package istio
 
 import (
+	"fmt"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
@@ -52,19 +53,34 @@ func Test_generateNewManifestWithoutIstioOperatorFrom(t *testing.T) {
 	})
 
 	t.Run("should return manifest without IstioOperator kind if it was not present ", func(t *testing.T) {
+		// given
+		require.Contains(t, istioManifestWithoutIstioOperator, "Kind1")
+		require.Contains(t, istioManifestWithoutIstioOperator, "Kind2")
+		require.NotContains(t, istioManifestWithoutIstioOperator, "IstioOperator")
+
 		// when
 		result := generateNewManifestWithoutIstioOperatorFrom(istioManifestWithoutIstioOperator)
 
 		// then
-		require.Equal(t, result, istioManifestWithoutIstioOperator)
+		require.Contains(t, result, "Kind1")
+		require.Contains(t, result, "Kind2")
+		require.NotContains(t, result, "IstioOperator")
 	})
 
 	t.Run("should return manifest without IstioOperator kind if it was present", func(t *testing.T) {
+		// given
+		require.Contains(t, istioManifest, "Kind1")
+		require.Contains(t, istioManifest, "Kind2")
+		require.Contains(t, istioManifest, "IstioOperator")
+
 		// when
 		result := generateNewManifestWithoutIstioOperatorFrom(istioManifest)
+		fmt.Println(result)
 
 		// then
-		require.Equal(t, result, istioManifestWithoutIstioOperator)
+		require.Contains(t, result, "Kind1")
+		require.Contains(t, result, "Kind2")
+		require.NotContains(t, result, "IstioOperator")
 	})
 
 }


### PR DESCRIPTION
**Description**:
- deploy `istio-configuration` k8s resources after performing Istio installation
- omit `IstioOperator` resource from manifest to avoid duplication