### PR TITLE
Skipping in Cluster Client on Error

### DIFF
--- a/pkg/reconciler/kubernetes/kubeclient/kubeclient.go
+++ b/pkg/reconciler/kubernetes/kubeclient/kubeclient.go
@@ -48,7 +48,8 @@ func NewInClusterClientSet(logger *zap.SugaredLogger) (*kubernetes.Clientset, er
 	if err != nil && err == rest.ErrNotInCluster {
 		return nil, nil
 	} else if err != nil {
-		return nil, err
+		logger.Infof("Not able to create in cluster client")
+		return nil, nil
 	}
 
 	inClusterClientSet, err := inClusterClient.GetClientSet()


### PR DESCRIPTION
In cluster client should not be created in case Reconciler is not run on correct Kubernetes environment.