### PR TITLE
Enable Istio reconcilation to the same version, loosen restrictions on image prefix naming

### DIFF
--- a/pkg/reconciler/instances/istio/action.go
+++ b/pkg/reconciler/instances/istio/action.go
@@ -65,7 +65,7 @@ func (a *ReconcileAction) Run(context *service.ActionContext) error {
 			return errors.Wrap(err, "Could not deploy Istio resources")
 		}
 	} else if canUpdate(ver, context.Logger) {
-		context.Logger.Infof("Istio version was detected on the cluster, updating from %s to %s...", ver.PilotVersion, ver.ClientVersion)
+		context.Logger.Infof("Istio version was detected on the cluster, updating pilot from %s and data plane from %s to version %s...", ver.PilotVersion, ver.DataPlaneVersion, ver.TargetVersion)
 
 		err = a.performer.Update(context.KubeClient.Kubeconfig(), manifest.Manifest, context.Logger)
 		if err != nil {
@@ -163,11 +163,6 @@ func canUpdate(ver actions.IstioVersion, logger *zap.SugaredLogger) bool {
 
 	if pilotVsTarget == -1 || dataPlaneVsTarget == -1 {
 		logger.Errorf("Downgrade detected from pilot: %s and data plane: %s to version: %s - finishing...", ver.PilotVersion, ver.DataPlaneVersion, ver.TargetVersion)
-		return false
-	}
-
-	if pilotVsTarget == 0 && dataPlaneVsTarget == 0 {
-		logger.Errorf("Current version: %s is the same as target version: %s - finishing...", ver.PilotVersion, ver.TargetVersion)
 		return false
 	}
 

--- a/pkg/reconciler/instances/istio/actions/performer.go
+++ b/pkg/reconciler/instances/istio/actions/performer.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	istioOperatorKind     = "IstioOperator"
-	istioImagePrefix      = "eu.gcr.io/kyma-project/external/istio/proxyv2"
+	istioImagePrefix      = "istio/proxyv2"
 	retriesCount          = 5
 	delayBetweenRetries   = 10
 	sleepAfterPodDeletion = 10


### PR DESCRIPTION
### Description
- enable Istio component reconciliation to the same version (configuration change)
- loosen restrictions on image prefix naming

### Links
See: https://github.com/kyma-incubator/reconciler/issues/247