### PR TITLE
Do not mark an operation as in_progress in the worker

### DIFF
--- a/pkg/scheduler/worker/worker.go
+++ b/pkg/scheduler/worker/worker.go
@@ -9,7 +9,6 @@ import (
 	"github.com/kyma-incubator/reconciler/pkg/scheduler/invoker"
 	"github.com/kyma-incubator/reconciler/pkg/scheduler/reconciliation"
 	"go.uber.org/zap"
-	"strings"
 	"time"
 )
 


### PR DESCRIPTION
The logic to mark the operation as in_progress was moved to the invoker and since the invoker checks the status before it runs, it will not do anything if the worker already marked it.