### PR TITLE
Generate value of SecretsCookie in Ory Hydra secret

### DIFF
--- a/pkg/reconciler/instances/ory/db/db.go
+++ b/pkg/reconciler/instances/ory/db/db.go
@@ -158,6 +158,7 @@ func (c *Config) prepareGenericDSN() string {
 
 func (c *Config) prepareStringData() map[string]string {
 	c.Global.Ory.Hydra.Persistence.SecretsSystem = generateRandomString(32)
+	c.Global.Ory.Hydra.Persistence.SecretsCookie = generateRandomString(32)
 
 	if c.Global.Ory.Hydra.Persistence.Enabled {
 		if c.Global.Ory.Hydra.Persistence.PostgresqlFlag.Enabled {


### PR DESCRIPTION
SecretsCookie should be generated and not empty on Install
```
The configuration contains values or keys which are invalid:
secrets.cookie: <nil>
                ^-- expected array, but got null

time=2021-11-09T16:33:42Z level=fatal msg=Unable to instantiate configuration. audience=application error=map[message:I[#/secrets/cookie] S[#/properties/secrets/properties/cookie/type] expected array, but got null] service_name=ORY Hydra service_version=v1.10.7
```