### PR TITLE
Fix kubeclient bug causing resource manifests not to regenerate.

### DIFF
--- a/pkg/reconciler/kubernetes/adapter/test/unittest-with-namespace.yaml
+++ b/pkg/reconciler/kubernetes/adapter/test/unittest-with-namespace.yaml
@@ -42,8 +42,14 @@ metadata:
   name: unittest-job
   # namespace has to be set during deployment
 spec:
+  selector:
+    matchLabels:
+      app: unittest-job
   template:
     spec:
+      metadata:
+        labels:
+          app: unittest-job
       containers:
         - name: unittest-job
           image: alpine

--- a/pkg/reconciler/kubernetes/adapter/test/unittest-with-namespace.yaml
+++ b/pkg/reconciler/kubernetes/adapter/test/unittest-with-namespace.yaml
@@ -42,14 +42,8 @@ metadata:
   name: unittest-job
   # namespace has to be set during deployment
 spec:
-  selector:
-    matchLabels:
-      app: unittest-job
   template:
     spec:
-      metadata:
-        labels:
-          app: unittest-job
       containers:
         - name: unittest-job
           image: alpine

--- a/pkg/reconciler/kubernetes/kubeclient/kubeclient.go
+++ b/pkg/reconciler/kubernetes/kubeclient/kubeclient.go
@@ -143,12 +143,6 @@ func (kube *KubeClient) ApplyWithNamespaceOverride(u *unstructured.Unstructured,
 			return metadata, err
 		}
 
-		// Create the resource if it doesn't exist
-		// First, update the annotation used by kubectl kubeClient
-		if err := util.CreateApplyAnnotation(u, unstructured.UnstructuredJSONScheme); err != nil {
-			return metadata, err
-		}
-
 		// Then create the resource and skip the three-way merge
 		_, err := helper.Create(info.Namespace, true, u)
 		if err != nil {

--- a/pkg/reconciler/kubernetes/kubeclient/kubeclient.go
+++ b/pkg/reconciler/kubernetes/kubeclient/kubeclient.go
@@ -135,7 +135,6 @@ func (kube *KubeClient) ApplyWithNamespaceOverride(u *unstructured.Unstructured,
 		Namespace:       u.GetNamespace(),
 		Name:            u.GetName(),
 		Source:          "",
-		Object:          u,
 		ResourceVersion: restMapping.Resource.Version,
 	}
 
@@ -151,16 +150,14 @@ func (kube *KubeClient) ApplyWithNamespaceOverride(u *unstructured.Unstructured,
 		}
 
 		// Then create the resource and skip the three-way merge
-		obj, err := helper.Create(info.Namespace, true, info.Object)
+		_, err := helper.Create(info.Namespace, true, info.Object)
 		if err != nil {
 			return metadata, err
 		}
-
-		_ = info.Refresh(obj, true)
 	}
 
 	replace := newReplace(helper)
-	replacedObject, err := replace(info.Object, info.Namespace, info.Name)
+	replacedObject, err := replace(u, u.GetNamespace(), u.GetName())
 	if err != nil {
 		return metadata, err
 	}

--- a/pkg/reconciler/kubernetes/kubeclient/kubeclient.go
+++ b/pkg/reconciler/kubernetes/kubeclient/kubeclient.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/util"
 )
 
 type Metadata struct {
@@ -144,7 +143,7 @@ func (kube *KubeClient) ApplyWithNamespaceOverride(u *unstructured.Unstructured,
 		}
 
 		// Then create the resource and skip the three-way merge
-		_, err := helper.Create(info.Namespace, true, u)
+		_, err := helper.Create(u.GetNamespace(), true, u)
 		if err != nil {
 			return metadata, err
 		}

--- a/pkg/reconciler/kubernetes/kubeclient/kubeclient.go
+++ b/pkg/reconciler/kubernetes/kubeclient/kubeclient.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/util"
 )
 
 type Metadata struct {
@@ -143,19 +142,16 @@ func (kube *KubeClient) ApplyWithNamespaceOverride(u *unstructured.Unstructured,
 			return metadata, err
 		}
 
-		// Create the resource if it doesn't exist
-		// First, update the annotation used by kubectl kubeClient
-		if err := util.CreateApplyAnnotation(info.Object, unstructured.UnstructuredJSONScheme); err != nil {
-			return metadata, err
-		}
-
 		// Then create the resource and skip the three-way merge
-		obj, err := helper.Create(u.GetNamespace(), true, u)
+		_, err := helper.Create(u.GetNamespace(), true, u)
 		if err != nil {
 			return metadata, err
 		}
 
-		_ = info.Refresh(obj, true)
+		metadata.Name = u.GetName()
+		metadata.Namespace = u.GetNamespace()
+		metadata.Kind = u.GroupVersionKind().Kind
+		return metadata, nil
 	}
 
 	replace := newReplace(helper)

--- a/pkg/reconciler/kubernetes/kubeclient/kubeclient.go
+++ b/pkg/reconciler/kubernetes/kubeclient/kubeclient.go
@@ -145,12 +145,12 @@ func (kube *KubeClient) ApplyWithNamespaceOverride(u *unstructured.Unstructured,
 
 		// Create the resource if it doesn't exist
 		// First, update the annotation used by kubectl kubeClient
-		if err := util.CreateApplyAnnotation(info.Object, unstructured.UnstructuredJSONScheme); err != nil {
+		if err := util.CreateApplyAnnotation(u, unstructured.UnstructuredJSONScheme); err != nil {
 			return metadata, err
 		}
 
 		// Then create the resource and skip the three-way merge
-		_, err := helper.Create(info.Namespace, true, info.Object)
+		_, err := helper.Create(info.Namespace, true, u)
 		if err != nil {
 			return metadata, err
 		}

--- a/pkg/reconciler/kubernetes/progress/testdata/all.yaml
+++ b/pkg/reconciler/kubernetes/progress/testdata/all.yaml
@@ -41,14 +41,10 @@ kind: Job
 metadata:
   name: unittest-job
   namespace: unittest-progress
+  labels:
+    app: unittest-job
 spec:
-  selector:
-    matchLabels:
-      app: unittest-job
   template:
-    metadata:
-      labels:
-        app: unittest-job
     spec:
       containers:
         - name: unittest-job

--- a/pkg/reconciler/kubernetes/progress/testdata/all.yaml
+++ b/pkg/reconciler/kubernetes/progress/testdata/all.yaml
@@ -42,7 +42,13 @@ metadata:
   name: unittest-job
   namespace: unittest-progress
 spec:
+  selector:
+    matchLabels:
+      app: unittest-job
   template:
+    metadata:
+      labels:
+        app: unittest-job
     spec:
       containers:
         - name: unittest-job


### PR DESCRIPTION
Fix kubeclient bug causing resource manifests not to regenerate.  

See also: https://github.com/kyma-incubator/reconciler/issues/368