### PR TITLE
Add runtime-monitoring-agent (rma) component reconciler

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -24,3 +24,6 @@
 
 # Connectivity Proxy reconciler
 /pkg/reconciler/instances/connectivityproxy/ @akgalwas @janmedrek @franpog859 @Maladie @rafalpotempa @koala7659 @ralikio
+
+# Runtime Monitoring Agent (rma) reconciler
+/pkg/reconciler/instances/rma/ @ebensom @AdrianPei @fhivemind @lauraanddola @life0215 @lumi017 @Balazs23 @tobiscr @varbanv

--- a/openapi/external_api.yaml
+++ b/openapi/external_api.yaml
@@ -522,8 +522,10 @@ components:
             subAccountID,
             serviceID,
             servicePlanID,
+            servicePlanName,
             shootName,
             instanceID,
+            region,
         ]
       properties:
         globalAccountID:
@@ -534,9 +536,13 @@ components:
           type: string
         servicePlanID:
           type: string
+        servicePlanName:
+          type: string
         shootName:
           type: string
         instanceID:
+          type: string
+        region:
           type: string
 
     component:

--- a/pkg/keb/model_gen.go
+++ b/pkg/keb/model_gen.go
@@ -101,8 +101,10 @@ type KymaConfig struct {
 type Metadata struct {
 	GlobalAccountID string `json:"globalAccountID"`
 	InstanceID      string `json:"instanceID"`
+	Region          string `json:"region"`
 	ServiceID       string `json:"serviceID"`
 	ServicePlanID   string `json:"servicePlanID"`
+	ServicePlanName string `json:"servicePlanName"`
 	ShootName       string `json:"shootName"`
 	SubAccountID    string `json:"subAccountID"`
 }

--- a/pkg/reconciler/instances/loader.go
+++ b/pkg/reconciler/instances/loader.go
@@ -19,6 +19,8 @@ import (
 	_ "github.com/kyma-incubator/reconciler/pkg/reconciler/instances/ory"
 	//import required to register component reconciler 'rafter' in reconciler registry
 	_ "github.com/kyma-incubator/reconciler/pkg/reconciler/instances/rafter"
+	//import required to register component reconciler 'rma' in reconciler registry
+	_ "github.com/kyma-incubator/reconciler/pkg/reconciler/instances/rma"
 	//import required to register component reconciler 'serverless' in reconciler registry
 	_ "github.com/kyma-incubator/reconciler/pkg/reconciler/instances/serverless"
 )

--- a/pkg/reconciler/instances/rma/integration_action.go
+++ b/pkg/reconciler/instances/rma/integration_action.go
@@ -112,7 +112,7 @@ func (a *IntegrationAction) Run(context *service.ActionContext) error {
 		return a.upgrade(context, cfg, chartURL, releaseName, namespace)
 	case model.OperationTypeDelete:
 		if err == nil {
-			return a.delete(context, cfg, releaseName)
+			return a.delete(cfg, releaseName)
 		}
 	}
 
@@ -175,7 +175,7 @@ func (a *IntegrationAction) upgrade(context *service.ActionContext, cfg *action.
 	return nil
 }
 
-func (a *IntegrationAction) delete(context *service.ActionContext, cfg *action.Configuration, releaseName string) error {
+func (a *IntegrationAction) delete(cfg *action.Configuration, releaseName string) error {
 	uninstallAction := action.NewUninstall(cfg)
 	uninstallAction.Timeout = 5 * time.Minute
 
@@ -252,8 +252,8 @@ func (a *IntegrationAction) fetchPasswordFromAuthSecret(ctx context.Context, rel
 	return string(password), nil
 }
 
-func (a *IntegrationAction) getChartVersionFromURL(chartUrl string) string {
-	match := a.chartVerExpr.FindStringSubmatch(chartUrl)
+func (a *IntegrationAction) getChartVersionFromURL(chartURL string) string {
+	match := a.chartVerExpr.FindStringSubmatch(chartURL)
 	if len(match) < 2 {
 		return ""
 	}

--- a/pkg/reconciler/instances/rma/integration_action.go
+++ b/pkg/reconciler/instances/rma/integration_action.go
@@ -1,0 +1,321 @@
+package rma
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"regexp"
+	"sync"
+	"time"
+
+	"github.com/kyma-incubator/reconciler/pkg/model"
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/kubernetes/kubeclient"
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/service"
+	"github.com/pkg/errors"
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/storage/driver"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	RmiHelmDriver      = "secret"
+	RmiHelmMaxHistory  = 1
+	RmiChartName       = "rmi"
+	RmiChartUrlConfig  = "rmi.chartUrl"
+	RmiNamespaceConfig = "rmi.namespace"
+)
+
+type IntegrationAction struct {
+	name         string
+	http         http.Client
+	kube         *kubeclient.KubeClient
+	mux          sync.Mutex
+	archives     map[string][]byte
+	chartVerExpr *regexp.Regexp
+}
+
+func NewIntegrationAction(name string, kubeClient *kubeclient.KubeClient) *IntegrationAction {
+
+	return &IntegrationAction{
+		name: name,
+		kube: kubeClient,
+		http: http.Client{
+			Timeout: 20 * time.Second,
+		},
+		archives:     make(map[string][]byte),
+		chartVerExpr: regexp.MustCompile(fmt.Sprintf("%s-([a-zA-Z0-9-.]+)\\.tgz$", RmiChartName)),
+	}
+}
+
+func (a *IntegrationAction) Run(context *service.ActionContext) error {
+	context.Logger.Infof("Performing %s action for shoot %s", a.name, context.Task.Metadata.ShootName)
+
+	chartUrl := getConfigString(context.Task.Configuration, RmiChartUrlConfig)
+	if chartUrl == "" {
+		err := fmt.Errorf("missing required configuration: %s", RmiChartUrlConfig)
+		return err
+	}
+	namespace := getConfigString(context.Task.Configuration, RmiNamespaceConfig)
+	if namespace == "" {
+		err := fmt.Errorf("missing required configuration: %s", RmiNamespaceConfig)
+		return err
+	}
+	releaseName := context.Task.Metadata.ShootName
+
+	cfg, err := a.newActionConfig(context, namespace)
+	if err != nil {
+		return err
+	}
+
+	histClient := action.NewHistory(cfg)
+	histClient.Max = 1
+	releases, err := histClient.Run(releaseName)
+	if err != nil && err != driver.ErrReleaseNotFound {
+		return errors.Wrapf(err, "while querying rmi helm history for release %s", releaseName)
+	}
+	helmRelease := findLatestRevision(releases)
+
+	switch context.Task.Type {
+	case model.OperationTypeReconcile:
+		// If a release does not exist, run helm install
+		if err == driver.ErrReleaseNotFound {
+			return a.install(context, cfg, chartUrl, releaseName, namespace)
+		}
+
+		// If the release exists, only run helm upgrade if the integration chart version is different.
+		// This is necessary to avoid overloading of the control plane K8S API as reconciliation for all runtimes are scheduled periodically.
+		// Proceed also with the upgrade if any of the chart versions cannot reliably be determined
+		upgradeVersion := a.getChartVersionFromURL(chartUrl)
+		releaseVersion := ""
+		if helmRelease.Chart != nil && helmRelease.Chart.Metadata != nil {
+			releaseVersion = helmRelease.Chart.Metadata.Version
+		}
+		switch {
+		case upgradeVersion == "" || releaseVersion == "":
+			context.Logger.Warnf("cannot reliably determine monitoring integration chart versions (release/upgrade: %s/%s). Proceeding with rmi upgrade...", releaseVersion, upgradeVersion)
+		case upgradeVersion == releaseVersion && helmRelease.Info.Status == release.StatusDeployed:
+			context.Logger.Infof("%s-%s target version matches release version, skipping upgrade.", RmiChartName, releaseName)
+			return nil
+		default:
+			context.Logger.Infof("%s-%s target version: %s release version/status: %s/%s, starting upgrade.", RmiChartName, releaseName, upgradeVersion, releaseVersion, helmRelease.Info.Status)
+		}
+
+		return a.upgrade(context, cfg, chartUrl, releaseName, namespace)
+	case model.OperationTypeDelete:
+		if err == nil {
+			return a.delete(context, cfg, releaseName)
+		}
+	}
+
+	return nil
+}
+
+func (a *IntegrationAction) install(context *service.ActionContext, cfg *action.Configuration, chartUrl, releaseName, namespace string) error {
+	installAction := action.NewInstall(cfg)
+	installAction.ReleaseName = releaseName
+	installAction.Namespace = namespace
+	installAction.Timeout = 6 * time.Minute
+	installAction.Wait = true
+	installAction.Atomic = true
+	chart, err := a.fetchChart(context.Context, chartUrl)
+	if err != nil {
+		context.Logger.Errorf("failed to fetch RMI chart from %s: %s", chartUrl, err)
+		return err
+	}
+	username := context.Task.Metadata.InstanceID
+	password := generatePassword(16)
+	overrides := generateOverrideMap(context, username, password)
+
+	_, err = installAction.Run(chart, overrides)
+	if err != nil {
+		context.Logger.Errorf("helm install %s failed: %s", releaseName, err)
+		return err
+	}
+
+	setAuthCredetialOverrides(context.Task.Configuration, username, password)
+	return nil
+}
+
+func (a *IntegrationAction) upgrade(context *service.ActionContext, cfg *action.Configuration, chartUrl, releaseName, namespace string) error {
+
+	upgradeAction := action.NewUpgrade(cfg)
+	upgradeAction.Namespace = namespace
+	upgradeAction.Timeout = 5 * time.Minute
+	upgradeAction.Wait = true
+	upgradeAction.Atomic = true
+	upgradeAction.MaxHistory = RmiHelmMaxHistory
+	chart, err := a.fetchChart(context.Context, chartUrl)
+	if err != nil {
+		context.Logger.Errorf("failed to fetch RMI chart from %s: %s", chartUrl, err)
+		return err
+	}
+
+	username := context.Task.Metadata.InstanceID
+	password, err := a.fetchPasswordFromAuthSecret(context.Context, releaseName, namespace)
+	if err != nil {
+		context.Logger.Errorf("failed to fetch auth credentials from secret: %s", err)
+		return err
+	}
+	overrides := generateOverrideMap(context, username, password)
+
+	_, err = upgradeAction.Run(releaseName, chart, overrides)
+	if err != nil {
+		context.Logger.Errorf("helm upgrade %s failed: %s", releaseName, err)
+		return err
+	}
+
+	setAuthCredetialOverrides(context.Task.Configuration, username, password)
+	return nil
+}
+
+func (c *IntegrationAction) delete(context *service.ActionContext, cfg *action.Configuration, releaseName string) error {
+	uninstallAction := action.NewUninstall(cfg)
+	uninstallAction.Timeout = 5 * time.Minute
+
+	_, err := uninstallAction.Run(releaseName)
+	if err != nil {
+		context.Logger.Errorf("helm delete %s failed: %s", releaseName, err)
+	}
+
+	return err
+}
+
+func (a *IntegrationAction) newActionConfig(context *service.ActionContext, namespace string) (*action.Configuration, error) {
+
+	cfg := new(action.Configuration)
+	if err := cfg.Init(a.kube.RESTClientGetter(), namespace, RmiHelmDriver, context.Logger.Debugf); err != nil {
+		return cfg, err
+	}
+
+	return cfg, nil
+}
+
+func (a *IntegrationAction) fetchChart(ctx context.Context, chartUrl string) (*chart.Chart, error) {
+	a.mux.Lock()
+	defer a.mux.Unlock()
+
+	archive := a.archives[chartUrl]
+	if archive == nil {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, chartUrl, nil)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := a.http.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+
+		archive, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("http status %s", resp.Status)
+		}
+
+		a.archives[chartUrl] = archive
+	}
+
+	chart, err := loader.LoadArchive(bytes.NewReader(archive))
+	if err != nil {
+		return nil, err
+	}
+
+	return chart, nil
+}
+
+func (a *IntegrationAction) fetchPasswordFromAuthSecret(ctx context.Context, release, namespace string) (string, error) {
+	client, err := a.kube.GetClientSet()
+	if err != nil {
+		return "", err
+	}
+	secret, err := client.CoreV1().Secrets(namespace).Get(ctx, fmt.Sprintf("vmuser-%s-%s", RmiChartName, release), metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	if secret.Data == nil {
+		return "", errors.New("secret data is empty")
+	}
+	password := secret.Data["password"]
+	if len(password) == 0 {
+		return "", errors.New("missing/empty auth credentials")
+	}
+
+	return string(password), nil
+}
+
+func (a *IntegrationAction) getChartVersionFromURL(chartUrl string) string {
+	match := a.chartVerExpr.FindStringSubmatch(chartUrl)
+	if len(match) < 2 {
+		return ""
+	}
+	return match[1]
+}
+
+func generatePassword(length int) string {
+	var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	rand.Seed(time.Now().UnixNano())
+	bytes := make([]rune, length)
+	for i := range bytes {
+		bytes[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+
+	return string(bytes)
+}
+
+func generateOverrideMap(context *service.ActionContext, username, password string) map[string]interface{} {
+	overrideMap := make(map[string]interface{})
+	metadata := context.Task.Metadata
+	overrideMap["runtime"] = map[string]string{
+		"instanceID":      metadata.InstanceID,
+		"globalAccountID": metadata.GlobalAccountID,
+		"subaccountID":    metadata.SubAccountID,
+		"shootName":       metadata.ShootName,
+		"planName":        metadata.ServicePlanName,
+		"region":          metadata.Region,
+	}
+	overrideMap["auth"] = map[string]string{
+		"username": username,
+		"password": password,
+	}
+
+	return overrideMap
+}
+
+func getConfigString(config map[string]interface{}, key string) string {
+	val, ok := config[key]
+	if !ok {
+		return ""
+	}
+	rv, ok := val.(string)
+	if !ok {
+		return ""
+	}
+
+	return rv
+}
+
+func setAuthCredetialOverrides(configuration map[string]interface{}, username, password string) {
+	configuration["vmuser.username"] = username
+	configuration["vmuser.password"] = password
+}
+
+func findLatestRevision(releases []*release.Release) *release.Release {
+	revision := -1
+	var release *release.Release = nil
+	for _, r := range releases {
+		if r.Version > revision {
+			release = r
+			revision = r.Version
+		}
+	}
+
+	return release
+}

--- a/pkg/reconciler/instances/rma/lazy_client.go
+++ b/pkg/reconciler/instances/rma/lazy_client.go
@@ -1,0 +1,44 @@
+package rma
+
+import (
+	"sync"
+
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/kubernetes/kubeclient"
+	"go.uber.org/zap"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
+)
+
+type KubeClient interface {
+	ClientSet() (kubernetes.Interface, error)
+	RESTClientGetter() (genericclioptions.RESTClientGetter, error)
+}
+
+type LazyKubeClient struct {
+	client     *kubeclient.KubeClient
+	clientErr  error
+	initClient sync.Once
+	log        *zap.SugaredLogger
+}
+
+func (c *LazyKubeClient) init() error {
+	c.initClient.Do(func() {
+		c.client, c.clientErr = kubeclient.NewInClusterClient(c.log)
+	})
+	return c.clientErr
+}
+
+func (c *LazyKubeClient) ClientSet() (kubernetes.Interface, error) {
+	if err := c.init(); err != nil {
+		return nil, err
+	}
+	return c.client.GetClientSet()
+}
+
+func (c *LazyKubeClient) RESTClientGetter() (genericclioptions.RESTClientGetter, error) {
+	if err := c.init(); err != nil {
+		return nil, err
+	}
+
+	return c.client.RESTClientGetter(), nil
+}

--- a/pkg/reconciler/instances/rma/rma.go
+++ b/pkg/reconciler/instances/rma/rma.go
@@ -2,7 +2,6 @@ package rma
 
 import (
 	"github.com/kyma-incubator/reconciler/pkg/logger"
-	"github.com/kyma-incubator/reconciler/pkg/reconciler/kubernetes/kubeclient"
 	"github.com/kyma-incubator/reconciler/pkg/reconciler/service"
 )
 
@@ -18,12 +17,10 @@ func init() {
 		log.Fatalf("Could not create '%s' component reconciler: %s", ReconcilerName, err)
 	}
 
-	kubeClient, err := kubeclient.NewInClusterClient(log)
-	if err != nil {
-		log.Fatalf("Could not initialize in-cluster k8s client: %s")
-	}
+	kubeClient := &LazyKubeClient{log: log}
 	reconciler.
-		//register reconciler pre-reconcile action (executed BEFORE reconciliation happens) and post-delete action (executed AFTER deletion happens)
+		// register reconciler pre-reconcile action (executed BEFORE reconciliation happens)
 		WithPreReconcileAction(NewIntegrationAction("runtime-monitoring-integration-reconcile", kubeClient)).
+		// register reconciler post-delete action (executed AFTER deletion happens)
 		WithPostDeleteAction(NewIntegrationAction("runtime-monitoring-integration-delete", kubeClient))
 }

--- a/pkg/reconciler/instances/rma/rma.go
+++ b/pkg/reconciler/instances/rma/rma.go
@@ -1,0 +1,29 @@
+package rma
+
+import (
+	"github.com/kyma-incubator/reconciler/pkg/logger"
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/kubernetes/kubeclient"
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/service"
+)
+
+const ReconcilerName = "rma"
+
+//nolint:gochecknoinits //usage of init() is intended to register reconciler-instances in centralized registry
+func init() {
+	log := logger.NewLogger(false)
+
+	log.Debugf("Initializing component reconciler '%s'", ReconcilerName)
+	reconciler, err := service.NewComponentReconciler(ReconcilerName)
+	if err != nil {
+		log.Fatalf("Could not create '%s' component reconciler: %s", ReconcilerName, err)
+	}
+
+	kubeClient, err := kubeclient.NewInClusterClient(log)
+	if err != nil {
+		log.Fatalf("Could not initialize in-cluster k8s client: %s")
+	}
+	reconciler.
+		//register reconciler pre-reconcile action (executed BEFORE reconciliation happens) and post-delete action (executed AFTER deletion happens)
+		WithPreReconcileAction(NewIntegrationAction("runtime-monitoring-integration-reconcile", kubeClient)).
+		WithPostDeleteAction(NewIntegrationAction("runtime-monitoring-integration-delete", kubeClient))
+}

--- a/pkg/reconciler/kubernetes/kubeclient/kubeclient.go
+++ b/pkg/reconciler/kubernetes/kubeclient/kubeclient.go
@@ -41,6 +41,7 @@ type KubeClient struct {
 	dynamicClient dynamic.Interface
 	config        *rest.Config
 	mapper        *restmapper.DeferredDiscoveryRESTMapper
+	getter        *SimpleRESTClientGetter
 }
 
 func NewInClusterClientSet(logger *zap.SugaredLogger) (kubernetes.Interface, error) {
@@ -93,6 +94,7 @@ func newForConfig(config *rest.Config) (*KubeClient, error) {
 		dynamicClient: dynamicClient,
 		config:        config,
 		mapper:        mapper,
+		getter:        NewRESTClientGetter(config),
 	}, nil
 }
 
@@ -171,6 +173,10 @@ func (kube *KubeClient) ApplyWithNamespaceOverride(u *unstructured.Unstructured,
 
 func (kube *KubeClient) GetClientSet() (*kubernetes.Clientset, error) {
 	return kubernetes.NewForConfig(kube.config)
+}
+
+func (kube *KubeClient) RESTClientGetter() *SimpleRESTClientGetter {
+	return kube.getter
 }
 
 func (kube *KubeClient) DeleteResourceByKindAndNameAndNamespace(kind, name, namespace string, do metav1.DeleteOptions) (*k8s.Resource, error) {

--- a/pkg/reconciler/model.go
+++ b/pkg/reconciler/model.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/kyma-incubator/reconciler/pkg/keb"
 	"github.com/kyma-incubator/reconciler/pkg/model"
 )
 
@@ -39,6 +40,7 @@ type Task struct {
 	Profile         string                 `json:"profile"`
 	Configuration   map[string]interface{} `json:"configuration"`
 	Kubeconfig      string                 `json:"kubeconfig"`
+	Metadata        keb.Metadata           `json:"metadata"`
 	CallbackURL     string                 `json:"callbackURL"` //CallbackURL is mandatory when component-reconciler runs in separate process
 	CorrelationID   string                 `json:"correlationID"`
 	Repository      *Repository            `json:"repository"`

--- a/pkg/scheduler/invoker/invoker.go
+++ b/pkg/scheduler/invoker/invoker.go
@@ -60,6 +60,7 @@ func (p *Params) newTask() *reconciler.Task {
 		Profile:         p.ClusterState.Configuration.KymaProfile,
 		Configuration:   configuration,
 		Kubeconfig:      p.ClusterState.Cluster.Kubeconfig,
+		Metadata:        *p.ClusterState.Cluster.Metadata,
 		CorrelationID:   p.CorrelationID,
 		Repository: &reconciler.Repository{
 			URL:            p.ComponentToReconcile.URL,

--- a/pkg/scheduler/invoker/test.go
+++ b/pkg/scheduler/invoker/test.go
@@ -16,6 +16,9 @@ var clusterStateMock = &cluster.State{
 		RuntimeID:  "testCluster",
 		Contract:   1,
 		Kubeconfig: "abc...",
+		Metadata: &keb.Metadata{
+			GlobalAccountID: "testID",
+		},
 	},
 	Configuration: &model.ClusterConfigurationEntity{
 		Version:        1,


### PR DESCRIPTION
The purpose of this component reconciler is to obsolete and migrate the runtime monitoring integration custom logic from KEB into reconciler:

- https://github.com/kyma-project/control-plane/tree/main/components/kyma-environment-broker/internal/monitoring
- https://github.com/kyma-project/control-plane/blob/main/components/kyma-environment-broker/internal/process/provisioning/monitoring_integration.go
- https://github.com/kyma-project/control-plane/blob/main/components/kyma-environment-broker/internal/process/upgrade_kyma/monitoring_upgrade.go
- https://github.com/kyma-project/control-plane/blob/main/components/kyma-environment-broker/internal/process/deprovisioning/monitoring_uninstall.go

There are many problems with the current integration related to the integration config on the control plane cluster is not installed/upgraded/deleted at nearly the same time with the monitoring agent component on the runtime.

The component reconciler solves this problem by implementing a custom action for the runtime-monitoring-agent (rma) to manage the runtime-monitoring-integration (rmi) configuration on the control-plane cluster as part of the component reconciliation.

