### PR TITLE
Split API, metrics and health routes

### DIFF
--- a/cmd/mothership/mothership/start/http.go
+++ b/cmd/mothership/mothership/start/http.go
@@ -101,12 +101,11 @@ func startWebserver(ctx context.Context, o *Options) error {
 
 	//metrics endpoint
 	metrics.RegisterAll(o.Registry.Inventory(), o.Logger())
-	// add metrics endpoint to a subrouter
-	router.PathPrefix("/metrics").Subrouter().Handle("", promhttp.Handler())
+	router.Handle("/metrics", promhttp.Handler())
 
-	//liveness and readiness checks are added to a subrouter to avoide using the auditlog middleware
-	router.PathPrefix("/health").Subrouter().HandleFunc("/live", live)
-	router.PathPrefix("/health").Subrouter().HandleFunc("/ready", ready(o))
+	//liveness and readiness checks
+	router.HandleFunc("/health/live", live)
+	router.HandleFunc("/health/ready", ready(o))
 
 	if o.AuditLog && o.AuditLogFile != "" && o.AuditLogTenantID != "" {
 		auditLogger, err := NewLoggerWithFile(o.AuditLogFile)

--- a/cmd/mothership/mothership/start/integration_test.go
+++ b/cmd/mothership/mothership/start/integration_test.go
@@ -369,6 +369,24 @@ func TestMothership(t *testing.T) {
 			url:    fmt.Sprintf("%s/clusters/%s", baseURL, clusterName2),
 			method: httpDelete,
 		},
+		{
+			name:             "Test metrics endpoint",
+			url:              fmt.Sprintf("http://localhost:%d/metrics", serverPort),
+			method:           httpGet,
+			expectedHTTPCode: 200,
+		},
+		{
+			name:             "Test liveness endpoint",
+			url:              fmt.Sprintf("http://localhost:%d/health/live", serverPort),
+			method:           httpGet,
+			expectedHTTPCode: 200,
+		},
+		{
+			name:             "Test readiness endpoint",
+			url:              fmt.Sprintf("http://localhost:%d/health/ready", serverPort),
+			method:           httpGet,
+			expectedHTTPCode: 200,
+		},
 	}
 
 	for _, testCase := range tests {


### PR DESCRIPTION
Replaces #441. It's not possible to exclude a subroute from a middleware if the middleware is applied on the "main route". This PR resolves the issue by splitting the main route to 3 subroutes:
- API
- metrics
- health
This way, the auditlog middleware can be applied only on the API route.

Additionally, this PR adds integration-test test cases for metrics and health endpoint to avoid having similar issues.