### PR TITLE
Adjust clusterIP in the service interceptor if it is equal to None

### DIFF
--- a/pkg/reconciler/service/servicesinterceptor.go
+++ b/pkg/reconciler/service/servicesinterceptor.go
@@ -36,8 +36,8 @@ func (s *ServicesInterceptor) Intercept(resource *unstructured.Unstructured, nam
 		return k8s.ContinueInterceptionResult, nil
 	}
 
-	//do not adjust the ClusterIP if it is empty or equals to "None"
-	if svc.Spec.ClusterIP != "" && strings.EqualFold(svc.Spec.ClusterIP, none) {
+	//adjust the ClusterIP field only if it is empty or equals to "None"
+	if svc.Spec.ClusterIP != "" && !strings.EqualFold(svc.Spec.ClusterIP, none) {
 		return k8s.ContinueInterceptionResult, nil
 	}
 

--- a/pkg/reconciler/service/servicesinterceptor.go
+++ b/pkg/reconciler/service/servicesinterceptor.go
@@ -32,8 +32,8 @@ func (s *ServicesInterceptor) Intercept(resource *unstructured.Unstructured, nam
 		return k8s.ContinueInterceptionResult, nil
 	}
 
-	//adjust the ClusterIP field only if it is empty
-	if svc.Spec.ClusterIP != "" {
+	//do not adjust the ClusterIP if it is empty or equals to "None"
+	if svc.Spec.ClusterIP != "" && strings.EqualFold(svc.Spec.ClusterIP, "None") {
 		return k8s.ContinueInterceptionResult, nil
 	}
 

--- a/pkg/reconciler/service/servicesinterceptor.go
+++ b/pkg/reconciler/service/servicesinterceptor.go
@@ -10,6 +10,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+const (
+	none = "None"
+)
+
 type ServicesInterceptor struct {
 	kubeClient k8s.Client
 }
@@ -33,7 +37,7 @@ func (s *ServicesInterceptor) Intercept(resource *unstructured.Unstructured, nam
 	}
 
 	//do not adjust the ClusterIP if it is empty or equals to "None"
-	if svc.Spec.ClusterIP != "" && strings.EqualFold(svc.Spec.ClusterIP, "None") {
+	if svc.Spec.ClusterIP != "" && strings.EqualFold(svc.Spec.ClusterIP, none) {
 		return k8s.ContinueInterceptionResult, nil
 	}
 

--- a/pkg/reconciler/service/servicesinterceptor_test.go
+++ b/pkg/reconciler/service/servicesinterceptor_test.go
@@ -50,7 +50,7 @@ func TestServicesInterceptor(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, unstructs, 2)
 
-	testAssertions := func(t *testing.T, service *unstructured.Unstructured, expectedClusterIP string) () {
+	testAssertions := func(t *testing.T, service *unstructured.Unstructured, expectedClusterIP string) {
 		serviceObject, err := toService(service)
 		require.NoError(t, err)
 		require.Equal(t, serviceObject.Spec.ClusterIP, expectedClusterIP)
@@ -78,7 +78,7 @@ func TestServicesInterceptor(t *testing.T) {
 
 	// check with "None" clusterIP
 	service = unstructs[1]
-	testAssertions(t, service, "None")
+	testAssertions(t, service, none)
 }
 
 func toService(unstruct *unstructured.Unstructured) (*v1.Service, error) {

--- a/pkg/reconciler/service/test/servicesinterceptor.yaml
+++ b/pkg/reconciler/service/test/servicesinterceptor.yaml
@@ -13,7 +13,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: unittest-servicesinterceptors2
-  namespace: unittest-servicesinterceptor2
+  namespace: unittest-servicesinterceptor
 spec:
   clusterIP: None
   ports:

--- a/pkg/reconciler/service/test/servicesinterceptor.yaml
+++ b/pkg/reconciler/service/test/servicesinterceptor.yaml
@@ -8,3 +8,15 @@ spec:
     - port: 443
       protocol: TCP
       targetPort: 8443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: unittest-servicesinterceptors2
+  namespace: unittest-servicesinterceptor2
+spec:
+  clusterIP: None
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443


### PR DESCRIPTION
**Description**

Currently we intercept services with clusterIp, which has the default "None" value, such as i.e. here https://github.com/kyma-project/kyma/blob/main/resources/eventing/charts/nats/templates/service.yaml#L18. This then leads to errors like this `spec.clusterIPs[0]: Invalid value: []string{"None"}: may not change once set') for component 'eventing' to caller` .

**Changes proposed in this pull request**:
- do not intercept services which current state have clusterIP equals "None"


**Related issue(s)**
https://github.com/kyma-project/kyma/issues/12697