### PR TITLE
Reconcile Cluster which are in error State

### DIFF
--- a/pkg/cluster/inventory.go
+++ b/pkg/cluster/inventory.go
@@ -48,7 +48,7 @@ func NewInventory(conn db.Connection, debug bool, collector metricsCollector) (I
 	return &DefaultInventory{repo, collector}, nil
 }
 
-func (i *DefaultInventory) CountRetries(runtimeId string, configVersion int64) (int, error) { // TODO Write Unit tests
+func (i *DefaultInventory) CountRetries(runtimeId string, configVersion int64) (int, error) {
 	q, err := db.NewQuery(i.Conn, &model.ClusterStatusEntity{}, i.Logger)
 	if err != nil {
 		return 0, err

--- a/pkg/cluster/inventory.go
+++ b/pkg/cluster/inventory.go
@@ -429,10 +429,10 @@ func (i *DefaultInventory) latestCluster(runtimeID string) (*model.ClusterEntity
 	return clusterEntity.(*model.ClusterEntity), nil
 }
 
-func (i *DefaultInventory) ClustersToReconcile(reconcileInterval time.Duration) ([]*State, error) {
+func (i *DefaultInventory) ClustersToReconcile(reconcileInterval time.Duration) ([]*State, error) {  // TODO: Adapt filter logic here
 	var filters []statusSQLFilter
 	if reconcileInterval > 0 {
-		filters = append(filters, &reconcileIntervalFilter{
+		filters = append(filters, &reconcileIntervalFilter{   // TODO: Adapt interval fo clusters in error state
 			reconcileInterval: reconcileInterval,
 		})
 	}

--- a/pkg/cluster/inventory.go
+++ b/pkg/cluster/inventory.go
@@ -23,7 +23,7 @@ type Inventory interface {
 	StatusChanges(runtimeID string, offset time.Duration) ([]*StatusChange, error)
 	ClustersToReconcile(reconcileInterval time.Duration) ([]*State, error)
 	ClustersNotReady() ([]*State, error)
-	CountRetries(runtimeId string, configVersion int64) (int, error)
+	CountRetries(runtimeID string, configVersion int64) (int, error)
 }
 
 type DefaultInventory struct {
@@ -48,12 +48,12 @@ func NewInventory(conn db.Connection, debug bool, collector metricsCollector) (I
 	return &DefaultInventory{repo, collector}, nil
 }
 
-func (i *DefaultInventory) CountRetries(runtimeId string, configVersion int64) (int, error) {
+func (i *DefaultInventory) CountRetries(runtimeID string, configVersion int64) (int, error) {
 	q, err := db.NewQuery(i.Conn, &model.ClusterStatusEntity{}, i.Logger)
 	if err != nil {
 		return 0, err
 	}
-	clusterStatuses, err := q.Select().Where(map[string]interface{}{"RuntimeID": runtimeId, "ConfigVersion": configVersion}).OrderBy(map[string]string{"ID": "desc"}).Limit(50).GetMany()
+	clusterStatuses, err := q.Select().Where(map[string]interface{}{"RuntimeID": runtimeID, "ConfigVersion": configVersion}).OrderBy(map[string]string{"ID": "desc"}).Limit(50).GetMany()
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/cluster/inventory_test.go
+++ b/pkg/cluster/inventory_test.go
@@ -288,12 +288,16 @@ func TestCountRetries(t *testing.T) {
 		require.NoError(t, err)
 		//update clusterState with retryableError state
 		clusterState, err = inventory.UpdateStatus(clusterState, model.ClusterStatusReconcileErrorRetryable)
+		require.NoError(t, err)
 		//update clusterState with final state; unequal to ClusterStatusReconcileError or ClusterStatusReconcileErrorRetryable
 		clusterState, err = inventory.UpdateStatus(clusterState, model.ClusterStatusReady)
+		require.NoError(t, err)
 		//update cluster state with a retryable error multiple times
 		for i := 0; i < expectedErrRetryable; i++ {
 			clusterState, err = inventory.UpdateStatus(clusterState, model.ClusterStatusReconcileErrorRetryable)
+			require.NoError(t, err)
 			clusterState, err = inventory.UpdateStatus(clusterState, model.ClusterStatusReconciling)
+			require.NoError(t, err)
 		}
 		//count how often retry happened
 		cnt, err := inventory.CountRetries(clusterState.Configuration.RuntimeID, clusterState.Configuration.Version)

--- a/pkg/cluster/inventory_test.go
+++ b/pkg/cluster/inventory_test.go
@@ -291,7 +291,7 @@ func TestCountRetries(t *testing.T) {
 		//update clusterState with final state; unequal to ClusterStatusReconcileError or ClusterStatusReconcileErrorRetryable
 		clusterState, err = inventory.UpdateStatus(clusterState, model.ClusterStatusReady)
 		//update cluster state with a retryable error multiple times
-		for i:=0; i< expectedErrRetryable; i++ {
+		for i := 0; i < expectedErrRetryable; i++ {
 			clusterState, err = inventory.UpdateStatus(clusterState, model.ClusterStatusReconcileErrorRetryable)
 			clusterState, err = inventory.UpdateStatus(clusterState, model.ClusterStatusReconciling)
 		}

--- a/pkg/cluster/inventory_test.go
+++ b/pkg/cluster/inventory_test.go
@@ -277,6 +277,30 @@ func TestInventory(t *testing.T) {
 	})
 }
 
+func TestCountRetries(t *testing.T) {
+	inventory := newInventory(t)
+
+	t.Run("Calculate retry count for a cluster", func(t *testing.T) {
+		expectedErrRetryable := 10
+		//create Cluster
+		expectedCluster := newCluster(t, 1, 1, false)
+		clusterState, err := inventory.CreateOrUpdate(1, expectedCluster)
+		require.NoError(t, err)
+		//update clusterState with retryableError state
+		clusterState, err = inventory.UpdateStatus(clusterState, model.ClusterStatusReconcileErrorRetryable)
+		//update clusterState with final state; unequal to ClusterStatusReconcileError or ClusterStatusReconcileErrorRetryable
+		clusterState, err = inventory.UpdateStatus(clusterState, model.ClusterStatusReady)
+		//update cluster state with a retryable error multiple times
+		for i:=0; i< expectedErrRetryable; i++ {
+			clusterState, err = inventory.UpdateStatus(clusterState, model.ClusterStatusReconcileErrorRetryable)
+			clusterState, err = inventory.UpdateStatus(clusterState, model.ClusterStatusReconciling)
+		}
+		//count how often retry happened
+		cnt, err := inventory.CountRetries(clusterState.Configuration.RuntimeID, clusterState.Configuration.Version)
+		require.NoError(t, err)
+		require.Equal(t, expectedErrRetryable, cnt)
+	})
+}
 func listStatuses(states []*State) []model.Status {
 	var result []model.Status
 	for _, state := range states {

--- a/pkg/cluster/inventory_test.go
+++ b/pkg/cluster/inventory_test.go
@@ -280,7 +280,21 @@ func TestInventory(t *testing.T) {
 func TestCountRetries(t *testing.T) {
 	inventory := newInventory(t)
 
-	t.Run("Calculate retry count for a cluster", func(t *testing.T) {
+	t.Run("Calculate retry count for a cluster in status READY", func(t *testing.T) {
+		//create Cluster
+		expectedCluster := newCluster(t, 1, 1, false)
+		clusterState, err := inventory.CreateOrUpdate(1, expectedCluster)
+		require.NoError(t, err)
+		//update clusterState with retryableError state
+		clusterState, err = inventory.UpdateStatus(clusterState, model.ClusterStatusReady)
+		require.NoError(t, err)
+		//count how often retry happened
+		cnt, err := inventory.CountRetries(clusterState.Configuration.RuntimeID, clusterState.Configuration.Version)
+		require.NoError(t, err)
+		require.Equal(t, 0, cnt)
+	})
+
+	t.Run("Calculate retry count for a  retryable cluster", func(t *testing.T) {
 		expectedErrRetryable := 10
 		//create Cluster
 		expectedCluster := newCluster(t, 1, 1, false)

--- a/pkg/cluster/mock.go
+++ b/pkg/cluster/mock.go
@@ -76,6 +76,6 @@ func (kp *MockKubeconfigProvider) Get() (string, error) {
 	return kp.KubeconfigResult, nil
 }
 
-func (i *MockInventory) CountRetries(runtimeId string, configVersion int64) (int, error) {
+func (i *MockInventory) CountRetries(runtimeID string, configVersion int64) (int, error) {
 	return i.RetriesCount, nil
 }

--- a/pkg/cluster/mock.go
+++ b/pkg/cluster/mock.go
@@ -22,6 +22,7 @@ type MockInventory struct {
 	DeleteResult              error
 	UpdateStatusResult        *State
 	ChangesResult             []*StatusChange
+	RetriesCount              int
 }
 
 func (i *MockInventory) CreateOrUpdate(contractVersion int64, cluster *keb.Cluster) (*State, error) {
@@ -73,4 +74,8 @@ func (kp *MockKubeconfigProvider) Get() (string, error) {
 		return string(kubeCfg), nil
 	}
 	return kp.KubeconfigResult, nil
+}
+
+func (i *MockInventory) CountRetries(runtimeId string, configVersion int64) (int, error) {
+	return i.RetriesCount, nil
 }

--- a/pkg/cluster/statusfilter.go
+++ b/pkg/cluster/statusfilter.go
@@ -48,11 +48,11 @@ func (rif *reconcileIntervalFilter) Filter(dbType db.Type, statusColHdr *db.Colu
 	}
 	switch dbType {
 	case db.Postgres:
-		return fmt.Sprintf(`%s = '%s' AND %s <= NOW() - INTERVAL '%.0f SECOND'`,
-			statusColName, model.ClusterStatusReady, createdColName, rif.reconcileInterval.Seconds()), nil
+		return fmt.Sprintf(`%s IN ('%s', '%s') AND %s <= NOW() - INTERVAL '%.0f SECOND'`,
+			statusColName, model.ClusterStatusReady, model.ClusterStatusReconcileErrorRetryable, createdColName, rif.reconcileInterval.Seconds()), nil
 	case db.SQLite:
-		return fmt.Sprintf(`%s = '%s' AND %s <= DATETIME('now', '-%.0f SECONDS')`,
-			statusColName, model.ClusterStatusReady, createdColName, rif.reconcileInterval.Seconds()), nil
+		return fmt.Sprintf(`%s IN ('%s', '%s') AND %s <= DATETIME('now', '-%.0f SECONDS')`,
+			statusColName, model.ClusterStatusReady, model.ClusterStatusReconcileErrorRetryable, createdColName, rif.reconcileInterval.Seconds()), nil
 	default:
 		return "", fmt.Errorf("database type '%s' is not supported by this filter", dbType)
 	}

--- a/pkg/model/clusterstatus.go
+++ b/pkg/model/clusterstatus.go
@@ -7,15 +7,16 @@ import (
 type Status string
 
 const (
-	ClusterStatusDeletePending     Status = "delete_pending"
-	ClusterStatusDeleting          Status = "deleting"
-	ClusterStatusDeleteError       Status = "delete_error"
-	ClusterStatusDeleted           Status = "deleted"
-	ClusterStatusReconcilePending  Status = "reconcile_pending"
-	ClusterStatusReconcileDisabled Status = "reconcile_disabled"
-	ClusterStatusReconciling       Status = "reconciling"
-	ClusterStatusReconcileError    Status = "error"
-	ClusterStatusReady             Status = "ready"
+	ClusterStatusDeletePending           Status = "delete_pending"
+	ClusterStatusDeleting                Status = "deleting"
+	ClusterStatusDeleteError             Status = "delete_error"
+	ClusterStatusDeleted                 Status = "deleted"
+	ClusterStatusReconcilePending        Status = "reconcile_pending"
+	ClusterStatusReconcileDisabled       Status = "reconcile_disabled"
+	ClusterStatusReconciling             Status = "reconciling"
+	ClusterStatusReconcileError          Status = "error"
+	ClusterStatusReconcileErrorRetryable Status = "error_retryable"
+	ClusterStatusReady                   Status = "ready"
 )
 
 func (s Status) IsDeletion() bool {
@@ -30,7 +31,7 @@ func (s Status) IsReconcileCandidate() bool {
 }
 
 func (s Status) IsFinal() bool {
-	return s == ClusterStatusReady || s == ClusterStatusReconcileError || s == ClusterStatusDeleted || s == ClusterStatusDeleteError
+	return s == ClusterStatusReady || s == ClusterStatusReconcileError || s == ClusterStatusDeleted || s == ClusterStatusDeleteError || s == ClusterStatusReconcileErrorRetryable
 }
 
 type ClusterStatus struct {
@@ -63,6 +64,8 @@ func NewClusterStatus(status Status) (*ClusterStatus, error) {
 		clusterStatus.ID = 7
 	case ClusterStatusDeleted:
 		clusterStatus.ID = 8
+	case ClusterStatusReconcileErrorRetryable:
+		clusterStatus.ID = 9
 	default:
 		return clusterStatus, fmt.Errorf("ClusterStatus '%s' is unknown", status)
 	}

--- a/pkg/scheduler/service/bookkeeper.go
+++ b/pkg/scheduler/service/bookkeeper.go
@@ -16,13 +16,13 @@ import (
 const (
 	defaultOperationsWatchInterval = 30 * time.Second
 	defaultOrphanOperationTimeout  = 10 * time.Minute
-	defaultMaxRetries = 150
+	defaultMaxRetries              = 150
 )
 
 type BookkeeperConfig struct {
 	OperationsWatchInterval time.Duration
 	OrphanOperationTimeout  time.Duration
-	MaxRetries int
+	MaxRetries              int
 }
 
 func (wc *BookkeeperConfig) validate() error {

--- a/pkg/scheduler/service/bookkeeper.go
+++ b/pkg/scheduler/service/bookkeeper.go
@@ -146,6 +146,7 @@ func (bk *bookkeeper) finishReconciliation(reconResult *ReconciliationResult) bo
 		}
 		if errCnt < bk.config.MaxRetries {
 			newClusterStatus = model.ClusterStatusReconcileErrorRetryable
+			bk.logger.Infof("Reconciliation for cluster with runtimeID %s and clusterConfig %d failed, reconciliation will be retried. Count of retries: %d", reconResult.reconEntity.RuntimeID, reconResult.reconEntity.ClusterConfig, errCnt)
 		}
 	}
 

--- a/pkg/scheduler/service/run_test.go
+++ b/pkg/scheduler/service/run_test.go
@@ -62,7 +62,7 @@ func TestRuntimeBuilder(t *testing.T) {
 	})
 
 	t.Run("Run remote with error", func(t *testing.T) {
-		runRemote(t, model.ClusterStatusReconcileError, 5*time.Second)
+		runRemote(t, model.ClusterStatusReconcileErrorRetryable, 5*time.Second)
 	})
 
 }
@@ -145,7 +145,7 @@ func runRemote(t *testing.T, expectedClusterStatus model.Status, timeout time.Du
 
 	newClusterState, err := inventory.GetLatest(clusterState.Cluster.RuntimeID)
 	require.NoError(t, err)
-	require.Equal(t, newClusterState.Status.Status, expectedClusterStatus)
+	require.Equal(t, expectedClusterStatus, newClusterState.Status.Status)
 }
 
 //setOperationState will update all operation status accordingly to expected cluster state

--- a/pkg/scheduler/service/run_test.go
+++ b/pkg/scheduler/service/run_test.go
@@ -156,6 +156,8 @@ func setOperationState(t *testing.T, reconRepo reconciliation.Repository, expect
 		opState = model.OperationStateError
 	case model.ClusterStatusReady:
 		opState = model.OperationStateDone
+	case model.ClusterStatusReconcileErrorRetryable:
+		opState = model.OperationStateError
 	default:
 		t.Logf("Cannot map cluster state '%s' to an operation state", expectedClusterStatus)
 		t.FailNow()


### PR DESCRIPTION
**Description**

- Introduction of new State `ClusterStatusReconcileErrorRetryable `
- `reconcileIntervalFilter ` now filters for `ClusterStatusReady ` and `ClusterStatusReconcileErrorRetryable` for reconciliation
- `ClusterStatusReconcileErrorRetryable` is a final State
- Default maximum retries for Cluster reconciliation is 150
- If retry count >= maximum retries, cluster gets Status `ClusterStatusReconcileError` and will not be retried

**Related Issue**
#464 