### PR TITLE
Create entire JWKS secret in Pre-Reconciliation

### DIFF
--- a/pkg/reconciler/instances/ory/action.go
+++ b/pkg/reconciler/instances/ory/action.go
@@ -59,14 +59,14 @@ func (a *preReconcileAction) Run(context *service.ActionContext) error {
 		return errors.Wrap(err, "failed to retrieve native Kubernetes GO client")
 	}
 
-	jwksSecretObject, err := getSecret(context.Context, client, jwksNamespacedName)
+	_, err = getSecret(context.Context, client, jwksNamespacedName)
 	if err != nil {
 		if !kerrors.IsNotFound(err) {
 			return errors.Wrap(err, "Could not get JWKS secret")
 		}
 
 		logger.Info("Ory JWKS secret does not exist, creating it now")
-		jwksSecretObject, err = jwks.Get(jwksNamespacedName, jwksAlg, jwksBits)
+		jwksSecretObject, err := jwks.Get(jwksNamespacedName, jwksAlg, jwksBits)
 		if err != nil {
 			return errors.Wrap(err, "failed to create jwks secret for ORY OathKeeper")
 		}

--- a/pkg/reconciler/instances/ory/ory.go
+++ b/pkg/reconciler/instances/ory/ory.go
@@ -21,7 +21,7 @@ func init() {
 		WithPreReconcileAction(&preReconcileAction{
 			&oryAction{step: "pre-reconcile"},
 		}).
-		WithPreDeleteAction(&preDeleteAction{
-			&oryAction{step: "pre-delete"},
+		WithPostDeleteAction(&postDeleteAction{
+			&oryAction{step: "post-delete"},
 		})
 }

--- a/pkg/reconciler/instances/ory/ory.go
+++ b/pkg/reconciler/instances/ory/ory.go
@@ -19,10 +19,7 @@ func init() {
 
 	reconciler.
 		WithPreReconcileAction(&preReconcileAction{
-			&oryAction{step: "pre-install"},
-		}).
-		WithPostReconcileAction(&postReconcileAction{
-			&oryAction{step: "post-install"},
+			&oryAction{step: "pre-reconcile"},
 		}).
 		WithPreDeleteAction(&preDeleteAction{
 			&oryAction{step: "pre-delete"},


### PR DESCRIPTION
**Description**
JWKS secret was created by helm and patched the reconciler. On reconciliation this used to cause the oathkeeper pods to restart. To avoid this we move the entire jwks secret creation logic to the reconciler.

**Related Issue**
See https://github.com/kyma-project/kyma/issues/12735