### PR TITLE
Increase Limit for CountRetries

### DIFF
--- a/pkg/cluster/inventory.go
+++ b/pkg/cluster/inventory.go
@@ -23,7 +23,7 @@ type Inventory interface {
 	StatusChanges(runtimeID string, offset time.Duration) ([]*StatusChange, error)
 	ClustersToReconcile(reconcileInterval time.Duration) ([]*State, error)
 	ClustersNotReady() ([]*State, error)
-	CountRetries(runtimeID string, configVersion int64) (int, error)
+	CountRetries(runtimeID string, configVersion int64, maxRetries int) (int, error)
 }
 
 type DefaultInventory struct {
@@ -48,12 +48,12 @@ func NewInventory(conn db.Connection, debug bool, collector metricsCollector) (I
 	return &DefaultInventory{repo, collector}, nil
 }
 
-func (i *DefaultInventory) CountRetries(runtimeID string, configVersion int64) (int, error) {
+func (i *DefaultInventory) CountRetries(runtimeID string, configVersion int64,  maxRetries int) (int, error) {
 	q, err := db.NewQuery(i.Conn, &model.ClusterStatusEntity{}, i.Logger)
 	if err != nil {
 		return 0, err
 	}
-	clusterStatuses, err := q.Select().Where(map[string]interface{}{"RuntimeID": runtimeID, "ConfigVersion": configVersion}).OrderBy(map[string]string{"ID": "desc"}).Limit(1000).GetMany()
+	clusterStatuses, err := q.Select().Where(map[string]interface{}{"RuntimeID": runtimeID, "ConfigVersion": configVersion}).OrderBy(map[string]string{"ID": "desc"}).Limit(maxRetries*5).GetMany()
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/cluster/inventory.go
+++ b/pkg/cluster/inventory.go
@@ -49,7 +49,7 @@ func NewInventory(conn db.Connection, debug bool, collector metricsCollector) (I
 }
 
 func (i *DefaultInventory) CountRetries(runtimeID string, configVersion int64, maxRetries int) (int, error) {
-	maxStatusHistoryLength := maxRetires * 5 //cluster can have three interims state between errors, thus 5 is more than enough
+	const maxStatusHistoryLength = maxRetries * 5 //cluster can have three interims state between errors, thus 5 is more than enough
 	q, err := db.NewQuery(i.Conn, &model.ClusterStatusEntity{}, i.Logger)
 	if err != nil {
 		return 0, err

--- a/pkg/cluster/inventory.go
+++ b/pkg/cluster/inventory.go
@@ -49,7 +49,7 @@ func NewInventory(conn db.Connection, debug bool, collector metricsCollector) (I
 }
 
 func (i *DefaultInventory) CountRetries(runtimeID string, configVersion int64, maxRetries int) (int, error) {
-	const maxStatusHistoryLength = maxRetries * 5 //cluster can have three interims state between errors, thus 5 is more than enough
+	var maxStatusHistoryLength = maxRetries * 5 //cluster can have three interims state between errors, thus 5 is more than enough
 	q, err := db.NewQuery(i.Conn, &model.ClusterStatusEntity{}, i.Logger)
 	if err != nil {
 		return 0, err

--- a/pkg/cluster/inventory.go
+++ b/pkg/cluster/inventory.go
@@ -49,11 +49,12 @@ func NewInventory(conn db.Connection, debug bool, collector metricsCollector) (I
 }
 
 func (i *DefaultInventory) CountRetries(runtimeID string, configVersion int64, maxRetries int) (int, error) {
+	maxStatusHistoryLength := maxRetires * 5 //cluster can have three interims state between errors, thus 5 is more than enough
 	q, err := db.NewQuery(i.Conn, &model.ClusterStatusEntity{}, i.Logger)
 	if err != nil {
 		return 0, err
 	}
-	clusterStatuses, err := q.Select().Where(map[string]interface{}{"RuntimeID": runtimeID, "ConfigVersion": configVersion}).OrderBy(map[string]string{"ID": "desc"}).Limit(maxRetries * 5).GetMany()
+	clusterStatuses, err := q.Select().Where(map[string]interface{}{"RuntimeID": runtimeID, "ConfigVersion": configVersion}).OrderBy(map[string]string{"ID": "desc"}).Limit(maxStatusHistoryLength).GetMany()
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/cluster/inventory.go
+++ b/pkg/cluster/inventory.go
@@ -53,7 +53,7 @@ func (i *DefaultInventory) CountRetries(runtimeID string, configVersion int64) (
 	if err != nil {
 		return 0, err
 	}
-	clusterStatuses, err := q.Select().Where(map[string]interface{}{"RuntimeID": runtimeID, "ConfigVersion": configVersion}).OrderBy(map[string]string{"ID": "desc"}).Limit(50).GetMany()
+	clusterStatuses, err := q.Select().Where(map[string]interface{}{"RuntimeID": runtimeID, "ConfigVersion": configVersion}).OrderBy(map[string]string{"ID": "desc"}).Limit(1000).GetMany()
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/cluster/inventory.go
+++ b/pkg/cluster/inventory.go
@@ -48,12 +48,12 @@ func NewInventory(conn db.Connection, debug bool, collector metricsCollector) (I
 	return &DefaultInventory{repo, collector}, nil
 }
 
-func (i *DefaultInventory) CountRetries(runtimeID string, configVersion int64,  maxRetries int) (int, error) {
+func (i *DefaultInventory) CountRetries(runtimeID string, configVersion int64, maxRetries int) (int, error) {
 	q, err := db.NewQuery(i.Conn, &model.ClusterStatusEntity{}, i.Logger)
 	if err != nil {
 		return 0, err
 	}
-	clusterStatuses, err := q.Select().Where(map[string]interface{}{"RuntimeID": runtimeID, "ConfigVersion": configVersion}).OrderBy(map[string]string{"ID": "desc"}).Limit(maxRetries*5).GetMany()
+	clusterStatuses, err := q.Select().Where(map[string]interface{}{"RuntimeID": runtimeID, "ConfigVersion": configVersion}).OrderBy(map[string]string{"ID": "desc"}).Limit(maxRetries * 5).GetMany()
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/cluster/inventory_test.go
+++ b/pkg/cluster/inventory_test.go
@@ -286,6 +286,9 @@ func TestCountRetries(t *testing.T) {
 		clusterState, err := inventory.CreateOrUpdate(1, expectedCluster)
 		require.NoError(t, err)
 		//update clusterState with retryableError state
+		clusterState, err = inventory.UpdateStatus(clusterState, model.ClusterStatusReconcileErrorRetryable)
+		require.NoError(t, err)
+		//update clusterState with ready state
 		clusterState, err = inventory.UpdateStatus(clusterState, model.ClusterStatusReady)
 		require.NoError(t, err)
 		//count how often retry happened
@@ -295,7 +298,7 @@ func TestCountRetries(t *testing.T) {
 	})
 
 	t.Run("Calculate retry count for a  retryable cluster", func(t *testing.T) {
-		expectedErrRetryable := 10
+		expectedErrRetryable := 50
 		//create Cluster
 		expectedCluster := newCluster(t, 1, 1, false)
 		clusterState, err := inventory.CreateOrUpdate(1, expectedCluster)

--- a/pkg/cluster/inventory_test.go
+++ b/pkg/cluster/inventory_test.go
@@ -317,7 +317,7 @@ func TestCountRetries(t *testing.T) {
 			require.NoError(t, err)
 		}
 		//count how often retry happened
-		cnt, err := inventory.CountRetries(clusterState.Configuration.RuntimeID, clusterState.Configuration.Version, 250)
+		cnt, err := inventory.CountRetries(clusterState.Configuration.RuntimeID, clusterState.Configuration.Version, 150)
 		require.NoError(t, err)
 		require.Equal(t, expectedErrRetryable, cnt)
 	})

--- a/pkg/cluster/inventory_test.go
+++ b/pkg/cluster/inventory_test.go
@@ -292,7 +292,7 @@ func TestCountRetries(t *testing.T) {
 		clusterState, err = inventory.UpdateStatus(clusterState, model.ClusterStatusReady)
 		require.NoError(t, err)
 		//count how often retry happened
-		cnt, err := inventory.CountRetries(clusterState.Configuration.RuntimeID, clusterState.Configuration.Version)
+		cnt, err := inventory.CountRetries(clusterState.Configuration.RuntimeID, clusterState.Configuration.Version, 10)
 		require.NoError(t, err)
 		require.Equal(t, 0, cnt)
 	})
@@ -317,7 +317,7 @@ func TestCountRetries(t *testing.T) {
 			require.NoError(t, err)
 		}
 		//count how often retry happened
-		cnt, err := inventory.CountRetries(clusterState.Configuration.RuntimeID, clusterState.Configuration.Version)
+		cnt, err := inventory.CountRetries(clusterState.Configuration.RuntimeID, clusterState.Configuration.Version, 250)
 		require.NoError(t, err)
 		require.Equal(t, expectedErrRetryable, cnt)
 	})

--- a/pkg/cluster/mock.go
+++ b/pkg/cluster/mock.go
@@ -76,6 +76,6 @@ func (kp *MockKubeconfigProvider) Get() (string, error) {
 	return kp.KubeconfigResult, nil
 }
 
-func (i *MockInventory) CountRetries(runtimeID string, configVersion int64) (int, error) {
+func (i *MockInventory) CountRetries(runtimeID string, configVersion int64, maxRetries int) (int, error) {
 	return i.RetriesCount, nil
 }

--- a/pkg/scheduler/service/bookkeeper.go
+++ b/pkg/scheduler/service/bookkeeper.go
@@ -145,7 +145,7 @@ func (bk *bookkeeper) finishReconciliation(reconResult *ReconciliationResult) bo
 	newClusterStatus := reconResult.GetResult()
 
 	if newClusterStatus == model.ClusterStatusReconcileError {
-		errCnt, err := bk.transition.inventory.CountRetries(reconResult.reconEntity.RuntimeID, reconResult.reconEntity.ClusterConfig)
+		errCnt, err := bk.transition.inventory.CountRetries(reconResult.reconEntity.RuntimeID, reconResult.reconEntity.ClusterConfig, bk.config.MaxRetries)
 		if err != nil {
 			bk.logger.Errorf("failed to count error for runtime %s with error: %s", reconResult.reconEntity.RuntimeID, err)
 		}


### PR DESCRIPTION
Issue: #516 

Fix:
Increase limit for CountRetires SQL query to a multiple of `maxRetries`