### PR TITLE
Use UTC timezone while looking for items to remove

### DIFF
--- a/pkg/scheduler/service/cleaner.go
+++ b/pkg/scheduler/service/cleaner.go
@@ -42,12 +42,12 @@ func (c *cleaner) Run(ctx context.Context, transition *ClusterStatusTransition, 
 }
 
 func (c *cleaner) purgeReconciliations(transition *ClusterStatusTransition, config *CleanerConfig) {
-	cretedBefore := time.Now().UTC().Add(-1 * config.PurgeEntitiesOlderThan)
+	deadline := time.Now().UTC().Add(-1 * config.PurgeEntitiesOlderThan)
 	reconciliations, err := transition.ReconciliationRepository().GetReconciliations(&reconciliation.WithCreationDateBefore{
-		Time: cretedBefore,
+		Time: deadline,
 	})
 	if err != nil {
-		c.logger.Errorf("Cleaner failed to get reconciliations older than %s: %s", cretedBefore.String(), err.Error())
+		c.logger.Errorf("Cleaner failed to get reconciliations older than %s: %s", deadline.String(), err.Error())
 	}
 
 	for i := range reconciliations {

--- a/pkg/scheduler/service/cleaner.go
+++ b/pkg/scheduler/service/cleaner.go
@@ -42,7 +42,7 @@ func (c *cleaner) Run(ctx context.Context, transition *ClusterStatusTransition, 
 }
 
 func (c *cleaner) purgeReconciliations(transition *ClusterStatusTransition, config *CleanerConfig) {
-	cretedBefore := time.Now().Add(-1 * config.PurgeEntitiesOlderThan)
+	cretedBefore := time.Now().UTC().Add(-1 * config.PurgeEntitiesOlderThan)
 	reconciliations, err := transition.ReconciliationRepository().GetReconciliations(&reconciliation.WithCreationDateBefore{
 		Time: cretedBefore,
 	})

--- a/pkg/scheduler/service/run_test.go
+++ b/pkg/scheduler/service/run_test.go
@@ -135,8 +135,8 @@ func runRemote(t *testing.T, expectedClusterStatus model.Status, timeout time.Du
 		ClusterReconcileInterval: 1 * time.Minute,
 	})
 	remoteRunner.WithCleanerConfig(&CleanerConfig{
-		PurgeEntitiesOlderThan: 15 * time.Second,
-		CleanerInterval:        15 * time.Second,
+		PurgeEntitiesOlderThan: 5 * time.Second,
+		CleanerInterval:        2 * time.Second,
 	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/pkg/scheduler/service/run_test.go
+++ b/pkg/scheduler/service/run_test.go
@@ -135,8 +135,8 @@ func runRemote(t *testing.T, expectedClusterStatus model.Status, timeout time.Du
 		ClusterReconcileInterval: 1 * time.Minute,
 	})
 	remoteRunner.WithCleanerConfig(&CleanerConfig{
-		PurgeEntitiesOlderThan: 5 * time.Second,
-		CleanerInterval:        2 * time.Second,
+		PurgeEntitiesOlderThan: 15 * time.Second,
+		CleanerInterval:        4 * time.Second,
 	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)


### PR DESCRIPTION
Use UTC time in DB queries as UTC is the default timezone in the used DBMS.

https://github.com/kyma-incubator/reconciler/issues/534