### PR TITLE
Strip namespace from templates of selected non namespaced kinds

### DIFF
--- a/pkg/reconciler/instances/clusteressentials/action_test.go
+++ b/pkg/reconciler/instances/clusteressentials/action_test.go
@@ -157,7 +157,7 @@ func setup() (kubernetes.Interface, CustomAction, *service.ActionContext) {
 	action := CustomAction{}
 	mockClient := mocks.Client{}
 	mockClient.On("Clientset").Return(k8sClient, nil)
-	mockClient.On("Deploy", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*rkubernetes.Resource{}, nil)
+	mockClient.On("Deploy", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*rkubernetes.Resource{}, nil)
 	configuration := map[string]interface{}{}
 	mockProvider := pmock.Provider{}
 	mockManifest := chart.Manifest{

--- a/pkg/reconciler/instances/connectivityproxy/command_test.go
+++ b/pkg/reconciler/instances/connectivityproxy/command_test.go
@@ -3,8 +3,9 @@ package connectivityproxy
 import (
 	"context"
 	"fmt"
-	"github.com/kyma-incubator/reconciler/pkg/logger"
 	"testing"
+
+	"github.com/kyma-incubator/reconciler/pkg/logger"
 
 	"github.com/kyma-incubator/reconciler/pkg/reconciler"
 	"github.com/kyma-incubator/reconciler/pkg/reconciler/chart"
@@ -117,7 +118,7 @@ func TestCommands(t *testing.T) {
 				Manifest: cpManifest("1.2.4")}, nil)
 		ctx := context.Background()
 		kubeClient := &mocks.Client{}
-		kubeClient.On("Deploy", ctx, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("*service.LabelsInterceptor"), mock.AnythingOfType("*service.AnnotationsInterceptor"), mock.AnythingOfType("*service.ServicesInterceptor"), mock.AnythingOfType("*service.PVCInterceptor")).
+		kubeClient.On("Deploy", ctx, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("*service.LabelsInterceptor"), mock.AnythingOfType("*service.AnnotationsInterceptor"), mock.AnythingOfType("*service.ServicesInterceptor"), mock.AnythingOfType("*service.PVCInterceptor"), mock.AnythingOfType("*service.ClusterWideResourceInterceptor")).
 			Return(nil, nil).Once()
 
 		actionContext := &service.ActionContext{
@@ -162,7 +163,7 @@ func TestCommands(t *testing.T) {
 				Manifest: emptyManifest}, nil)
 		ctx := context.Background()
 		kubeClient := &mocks.Client{}
-		kubeClient.On("Deploy", ctx, emptyManifest, mock.AnythingOfType("string"), mock.AnythingOfType("*service.LabelsInterceptor"), mock.AnythingOfType("*service.AnnotationsInterceptor"), mock.AnythingOfType("*service.ServicesInterceptor"), mock.AnythingOfType("*service.PVCInterceptor")).
+		kubeClient.On("Deploy", ctx, emptyManifest, mock.AnythingOfType("string"), mock.AnythingOfType("*service.LabelsInterceptor"), mock.AnythingOfType("*service.AnnotationsInterceptor"), mock.AnythingOfType("*service.ServicesInterceptor"), mock.AnythingOfType("*service.PVCInterceptor"), mock.AnythingOfType("*service.ClusterWideResourceInterceptor")).
 			Return(nil, nil).Once()
 
 		actionContext := &service.ActionContext{
@@ -203,7 +204,7 @@ func TestCommands(t *testing.T) {
 
 		ctx := context.Background()
 		kubeClient := &mocks.Client{}
-		kubeClient.On("Deploy", ctx, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("*service.LabelsInterceptor"), mock.AnythingOfType("*service.AnnotationsInterceptor"), mock.AnythingOfType("*service.ServicesInterceptor"), mock.AnythingOfType("*service.PVCInterceptor")).
+		kubeClient.On("Deploy", ctx, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("*service.LabelsInterceptor"), mock.AnythingOfType("*service.AnnotationsInterceptor"), mock.AnythingOfType("*service.ServicesInterceptor"), mock.AnythingOfType("*service.PVCInterceptor"), mock.AnythingOfType("*service.ClusterWideResourceInterceptor")).
 			Return(nil, nil).Once()
 		actionContext := &service.ActionContext{
 			Context:       ctx,
@@ -241,7 +242,7 @@ func TestCommands(t *testing.T) {
 
 		ctx := context.Background()
 		kubeClient := &mocks.Client{}
-		kubeClient.On("Deploy", ctx, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("*service.LabelsInterceptor"), mock.AnythingOfType("*service.AnnotationsInterceptor"), mock.AnythingOfType("*service.ServicesInterceptor"), mock.AnythingOfType("*service.PVCInterceptor")).
+		kubeClient.On("Deploy", ctx, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("*service.LabelsInterceptor"), mock.AnythingOfType("*service.AnnotationsInterceptor"), mock.AnythingOfType("*service.ServicesInterceptor"), mock.AnythingOfType("*service.PVCInterceptor"), mock.AnythingOfType("*service.ClusterWideResourceInterceptor")).
 			Return(nil, nil).Once()
 		actionContext := &service.ActionContext{
 			Context:       ctx,

--- a/pkg/reconciler/instances/istio/istio_test.go
+++ b/pkg/reconciler/instances/istio/istio_test.go
@@ -310,7 +310,7 @@ func newFakeKubeClient() *k8smocks.Client {
 	})
 	mockClient.On("Clientset").Return(fakeClient, nil)
 	mockClient.On("Kubeconfig").Return("kubeconfig")
-	mockClient.On("Deploy", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+	mockClient.On("Deploy", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
 	mockClient.On("CoreV1").Return(nil)
 	mockClient.On("Delete", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
 	mockClient.On("PatchUsingStrategy", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)

--- a/pkg/reconciler/instances/serverless/action_test.go
+++ b/pkg/reconciler/instances/serverless/action_test.go
@@ -213,7 +213,7 @@ func setup() (kubernetes.Interface, ReconcileCustomAction, *service.ActionContex
 	action := ReconcileCustomAction{}
 	mockClient := mocks.Client{}
 	mockClient.On("Clientset").Return(k8sClient, nil)
-	mockClient.On("Deploy", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*rkubernetes.Resource{}, nil)
+	mockClient.On("Deploy", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*rkubernetes.Resource{}, nil)
 	configuration := map[string]interface{}{}
 	mockProvider := pmock.Provider{}
 	mockManifest := chart.Manifest{

--- a/pkg/reconciler/kubernetes/resource.go
+++ b/pkg/reconciler/kubernetes/resource.go
@@ -2,8 +2,9 @@ package kubernetes
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 type cache map[string][]*unstructured.Unstructured
@@ -67,6 +68,17 @@ func (r *ResourceList) Visit(callback func(u *unstructured.Unstructured) error) 
 
 func (r *ResourceList) VisitByKind(kind string, callback func(u *unstructured.Unstructured) error) error {
 	return r.visit(r.cache.GetKind(kind), callback)
+}
+
+func (r *ResourceList) VisitByKindAndAPIVersion(kind string, apiversion string, callback func(u *unstructured.Unstructured) error) error {
+	cachedByKind := r.cache.GetKind(kind)
+	cachedByKindAndVersion := make([]*unstructured.Unstructured, 0)
+	for i := range cachedByKind {
+		if cachedByKind[i].GetAPIVersion() == apiversion {
+			cachedByKindAndVersion = append(cachedByKindAndVersion, cachedByKind[i])
+		}
+	}
+	return r.visit(cachedByKindAndVersion, callback)
 }
 
 func (r *ResourceList) Get(kind, name, namespace string) *unstructured.Unstructured {

--- a/pkg/reconciler/service/clusterwideresourceinterceptor.go
+++ b/pkg/reconciler/service/clusterwideresourceinterceptor.go
@@ -1,0 +1,59 @@
+package service
+
+import (
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/kubernetes"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type clusterWideResource struct {
+	kind       string
+	apiVersion string
+}
+
+type ClusterWideResourceInterceptor struct {
+	clusterWideResources []clusterWideResource
+}
+
+func (c *ClusterWideResourceInterceptor) Intercept(resources *kubernetes.ResourceList, namespace string) error {
+	interceptorFunc := func(u *unstructured.Unstructured) error {
+		//clean namespace field from cluster-wide resource template
+		u.SetNamespace("")
+		return nil
+	}
+
+	for i := range c.clusterWideResources {
+		err := resources.VisitByKindAndAPIVersion(c.clusterWideResources[i].kind, c.clusterWideResources[i].apiVersion, interceptorFunc)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func newClusterWideResourceInterceptor() *ClusterWideResourceInterceptor {
+	return &ClusterWideResourceInterceptor{
+		clusterWideResources: []clusterWideResource{
+			{
+				kind:       "clusterrolebindings",
+				apiVersion: "rbac.authorization.k8s.io/v1",
+			},
+			{
+				kind:       "clusterroles",
+				apiVersion: "rbac.authorization.k8s.io/v1",
+			},
+			{
+				kind:       "mutatingwebhookconfigurations",
+				apiVersion: "admissionregistration.k8s.io/v1",
+			},
+			{
+				kind:       "validatingwebhookconfigurations",
+				apiVersion: "admissionregistration.k8s.io/v1",
+			},
+			{
+				kind:       "podsecuritypolicies",
+				apiVersion: "policy/v1beta1",
+			},
+		},
+	}
+}

--- a/pkg/reconciler/service/clusterwideresourceinterceptor_test.go
+++ b/pkg/reconciler/service/clusterwideresourceinterceptor_test.go
@@ -1,0 +1,72 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/kubernetes"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestClusterWideResourceInterceptor_Intercept(t *testing.T) {
+
+	tests := []struct {
+		name              string
+		resource          *unstructured.Unstructured
+		wantErr           bool
+		expectedNamespace string
+	}{
+		{
+			name: "Should not clear namespace for deployments",
+			resource: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"namespace": "foo",
+					},
+				},
+			},
+			wantErr:           false,
+			expectedNamespace: "foo",
+		},
+		{
+			name: "Should clear namespace for rbac.authorization.k8s.io/v1/ClusterRoles",
+			resource: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "rbac.authorization.k8s.io/v1",
+					"kind":       "ClusterRoles",
+					"metadata": map[string]interface{}{
+						"namespace": "foo",
+					},
+				},
+			},
+			wantErr:           false,
+			expectedNamespace: "",
+		},
+		{
+			name: "Should not clear namespace for yada/ClusterRoles",
+			resource: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "yada",
+					"kind":       "ClusterRoles",
+					"metadata": map[string]interface{}{
+						"namespace": "foo",
+					},
+				},
+			},
+			wantErr:           false,
+			expectedNamespace: "foo",
+		},
+	}
+	for _, tt := range tests {
+		testCase := tt
+		t.Run(testCase.name, func(t *testing.T) {
+			i := newClusterWideResourceInterceptor()
+			if err := i.Intercept(kubernetes.NewResourceList([]*unstructured.Unstructured{testCase.resource}), ""); (err != nil) != testCase.wantErr {
+				t.Errorf("ClusterWideResourceInterceptor.Intercept() error = %v, wantErr %v", err, testCase.wantErr)
+			}
+			require.Equal(t, testCase.expectedNamespace, testCase.resource.GetNamespace())
+		})
+	}
+}

--- a/pkg/reconciler/service/install.go
+++ b/pkg/reconciler/service/install.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+
 	"github.com/kyma-incubator/reconciler/pkg/model"
 	"github.com/kyma-incubator/reconciler/pkg/reconciler"
 	"github.com/kyma-incubator/reconciler/pkg/reconciler/chart"
@@ -60,6 +61,7 @@ func (r *Install) Invoke(ctx context.Context, chartProvider chart.Provider, task
 				kubeClient: kubeClient,
 				logger:     r.logger,
 			},
+			newClusterWideResourceInterceptor(),
 		)
 		if err == nil {
 			r.logger.Debugf("Deployment of manifest finished successfully: %d resources deployed", len(resources))


### PR DESCRIPTION
Remove `namespace` field  from templates for some selected cluster-wide resources where we realise namespace caused problems in rendering of kyma resources at the reconciler