### PR TITLE
Re-enable clusters

### DIFF
--- a/pkg/cluster/inventory.go
+++ b/pkg/cluster/inventory.go
@@ -221,9 +221,6 @@ func (i *DefaultInventory) createStatus(configEntity *model.ClusterConfiguration
 			i.Logger.Debugf("No differences found for status of cluster '%s': not creating new database entity", configEntity.RuntimeID)
 			return oldStatusEntity, nil
 		}
-		if oldStatusEntity.Status.IsDisabled() {
-			newStatusEntity.Status = model.ClusterStatusReconcileDisabled
-		}
 	} else if !repository.IsNotFoundError(err) {
 		//unexpected error
 		return nil, err


### PR DESCRIPTION
Move disabled check to only KEB calls, making it possible again to re-enable disabled clusters from KCP.