### PR TITLE
Adding compass-runtime-agent and application-connector as pre components

### DIFF
--- a/configs/reconciler.yaml
+++ b/configs/reconciler.yaml
@@ -27,4 +27,4 @@ mothership:
       base:
         url: "http://localhost:8081/v1/run"
     preComponents:
-      - [cluster-essentials, istio-configuration, certificates, application-connector, compass-runtime-agent]
+      - [cluster-essentials, istio-configuration, certificates, application-connector]

--- a/configs/reconciler.yaml
+++ b/configs/reconciler.yaml
@@ -27,4 +27,4 @@ mothership:
       base:
         url: "http://localhost:8081/v1/run"
     preComponents:
-      - [cluster-essentials, istio-configuration, certificates]
+      - [cluster-essentials, istio-configuration, certificates, application-connector, compass-runtime-agent]


### PR DESCRIPTION
In order to be successfully installed `compass-runtime-agent` requires `application-connector` component to be installed first. 