### PR TITLE
Fix helm chart pathing bug

### DIFF
--- a/pkg/reconciler/chart/component.go
+++ b/pkg/reconciler/chart/component.go
@@ -15,6 +15,10 @@ type Component struct {
 	configuration map[string]interface{}
 }
 
+func (c *Component) isExternalComponent() bool {
+	return c.url != ""
+}
+
 func (c *Component) isExternalGitComponent() bool {
 	return strings.HasSuffix(c.url, ".git")
 }

--- a/pkg/reconciler/chart/factory.go
+++ b/pkg/reconciler/chart/factory.go
@@ -152,7 +152,7 @@ func (f *DefaultFactory) getExternalArchiveComponent(component *Component) (*Wor
 	wsDir := f.componentBaseDir(component)
 
 	if f.readyMarkerExists(wsDir) {
-		return newComponentWorkspace(wsDir, component.name)
+		return newComponentWorkspace(wsDir)
 	}
 
 	if err := f.cleanFailedWorkspace(wsDir); err != nil {
@@ -166,7 +166,7 @@ func (f *DefaultFactory) getExternalArchiveComponent(component *Component) (*Wor
 		return nil, err
 	}
 
-	return newComponentWorkspace(wsDir, component.name)
+	return newComponentWorkspace(wsDir)
 }
 
 func (f *DefaultFactory) getExternalGitComponent(component *Component) (*Workspace, error) {
@@ -189,7 +189,7 @@ func (f *DefaultFactory) getExternalGitComponent(component *Component) (*Workspa
 	if err != nil {
 		return nil, err
 	}
-	return newComponentWorkspace(wsDir, component.name)
+	return newComponentWorkspace(wsDir)
 }
 
 func (f *DefaultFactory) cloneComponent(component *Component, dstDir string) error {

--- a/pkg/reconciler/chart/provider.go
+++ b/pkg/reconciler/chart/provider.go
@@ -7,6 +7,7 @@ import (
 
 	fileUtils "github.com/kyma-incubator/reconciler/pkg/files"
 	reconcilerK8s "github.com/kyma-incubator/reconciler/pkg/reconciler/kubernetes"
+	"github.com/pkg/errors"
 
 	"go.uber.org/zap"
 )
@@ -114,17 +115,17 @@ func (p *DefaultProvider) RenderCRD(version string) ([]*Manifest, error) {
 func (p *DefaultProvider) RenderManifest(component *Component) (*Manifest, error) {
 	wsDir, err := p.workspaceDir(component)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to create workspace dir")
 	}
 
 	helmClient, err := NewHelmClient(wsDir, p.logger)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to create new helm client")
 	}
 
 	manifest, err := helmClient.Render(component)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed helm client render")
 	}
 
 	for _, f := range p.filters {

--- a/pkg/reconciler/chart/workspace.go
+++ b/pkg/reconciler/chart/workspace.go
@@ -2,8 +2,8 @@ package chart
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
-	"path"
 	"path/filepath"
 
 	file "github.com/kyma-incubator/reconciler/pkg/files"
@@ -44,19 +44,27 @@ var validateDir = func(w *Workspace) error {
 	return nil
 }
 
-func validateFile(filepath string) func(*Workspace) error {
+func containsFile(filename string) func(*Workspace) error {
 	return func(w *Workspace) error {
-		charPath := path.Join(w.WorkspaceDir, filepath)
-		if _, err := os.Stat(charPath); err != nil {
+		found := false
+		err := filepath.WalkDir(w.WorkspaceDir, func(path string, d fs.DirEntry, err error) error {
+			if filepath.Base(path) == filename {
+				found = true
+			}
+			return nil
+		})
+		if !found {
+			return fmt.Errorf("Failed to find %v in %v", filename, w.WorkspaceDir)
+		}
+		if err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func newComponentWorkspace(workspaceDir, componentName string) (*Workspace, error) {
-	chartLocation := path.Join(componentName, "Chart.yaml")
-	validateChart := validateFile(chartLocation)
+func newComponentWorkspace(workspaceDir string) (*Workspace, error) {
+	validateChart := containsFile("Chart.yaml")
 	return newWorkspace(workspaceDir, validateDir, validateChart)
 }
 


### PR DESCRIPTION
Installing component via regular helm chart created by `helm pack` fails
```
Running=btp-operator[4][error: Failed to get manifest for component 'btp-operator' in Kyma version '2.0.0' using repository 'https://github.com/kyma-incubator/sap-btp-service-operator/releases/download/v0.1.18-custom/sap-btp-operator-0.1.18.tar.gz' : stat /tmp/reconciler/dcdb6d7dd915d574d31e7ffd286d16921cee1fe0-btp-operator/btp-operator/Chart.yaml: no such file or directory
```

However, running the chart by `helm` works well
```
$ helm template https://github.com/kyma-incubator/sap-btp-service-operator/releases/download/v0.1.18-custom/sap-btp-operator-0.1.18.tar.gz
```

This is an effort to enhance support for any valid helm chart by recursively looking for `Chart.yaml` instead of having the path hardcoded.

closes: https://github.com/kyma-incubator/reconciler/issues/527