### PR TITLE
Remove cluster_version & configuration_version from label set

### DIFF
--- a/pkg/metrics/reconciliation_status.go
+++ b/pkg/metrics/reconciliation_status.go
@@ -1,8 +1,6 @@
 package metrics
 
 import (
-	"fmt"
-
 	"github.com/kyma-incubator/reconciler/pkg/cluster"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -34,7 +32,7 @@ func NewReconciliationStatusCollector() *ReconciliationStatusCollector {
 			Subsystem: prometheusSubsystem,
 			Name:      "reconciliation_status",
 			Help:      "Status of the reconciliation",
-		}, []string{"runtime_id", "runtime_name", "cluster_version", "configuration_version"}),
+		}, []string{"runtime_id", "runtime_name"}),
 	}
 	prometheus.MustRegister(collector)
 	return collector
@@ -55,7 +53,7 @@ func (c *ReconciliationStatusCollector) OnClusterStateUpdate(state *cluster.Stat
 	}
 
 	c.reconciliationStatusGauge.
-		WithLabelValues(state.Cluster.RuntimeID, state.Cluster.Runtime.Name, fmt.Sprintf("%d", state.Cluster.Version), fmt.Sprintf("%d", state.Configuration.Version)).
+		WithLabelValues(state.Cluster.RuntimeID, state.Cluster.Runtime.Name).
 		Set(status.ID)
 
 	return nil


### PR DESCRIPTION
Remove cluster_version & configuration_version from `reconciliation_status` label set  to ensure one gauge per runtime.