### PR TITLE
Fix setting rma authentication overrides

### DIFF
--- a/pkg/reconciler/instances/rma/integration_action.go
+++ b/pkg/reconciler/instances/rma/integration_action.go
@@ -143,7 +143,7 @@ func (a *IntegrationAction) install(context *service.ActionContext, cfg *action.
 		return errors.WithMessagef(err, "helm install %s-%s failed", RmiChartName, releaseName)
 	}
 
-	setAuthCredetialOverrides(context.Task.Configuration, username, password)
+	setAuthCredentialOverrides(context.Task.Configuration, username, password)
 	a.setPassword(username, password)
 	return nil
 }
@@ -155,7 +155,7 @@ func (a *IntegrationAction) upgrade(context *service.ActionContext, cfg *action.
 		return errors.WithMessage(err, "failed to fetch auth credentials from secret")
 	}
 
-	setAuthCredetialOverrides(context.Task.Configuration, username, password)
+	setAuthCredentialOverrides(context.Task.Configuration, username, password)
 
 	if skipHelmUpgrade {
 		return nil
@@ -324,7 +324,7 @@ func getConfigString(config map[string]interface{}, key string) string {
 	return rv
 }
 
-func setAuthCredetialOverrides(configuration map[string]interface{}, username, password string) {
+func setAuthCredentialOverrides(configuration map[string]interface{}, username, password string) {
 	configuration["vmuser.username"] = username
 	configuration["vmuser.password"] = password
 }

--- a/pkg/reconciler/instances/rma/integration_action.go
+++ b/pkg/reconciler/instances/rma/integration_action.go
@@ -37,6 +37,7 @@ type IntegrationAction struct {
 	client       IntegrationClient
 	mux          sync.Mutex
 	archives     map[string][]byte
+	pwds         map[string]string
 	chartVerExpr *regexp.Regexp
 }
 
@@ -48,6 +49,7 @@ func NewIntegrationAction(name string, client IntegrationClient) *IntegrationAct
 			Timeout: 20 * time.Second,
 		},
 		archives:     make(map[string][]byte),
+		pwds:         make(map[string]string),
 		chartVerExpr: regexp.MustCompile(fmt.Sprintf("%s-([a-zA-Z0-9-.]+)\\.tgz$", RmiChartName)),
 	}
 }
@@ -97,20 +99,21 @@ func (a *IntegrationAction) Run(context *service.ActionContext) error {
 		if helmRelease.Chart != nil && helmRelease.Chart.Metadata != nil {
 			releaseVersion = helmRelease.Chart.Metadata.Version
 		}
+		skipHelmUpgrade := false
 		switch {
 		case upgradeVersion == "" || releaseVersion == "":
 			context.Logger.Warnf("cannot reliably determine monitoring integration chart versions (release/upgrade: %s/%s). Proceeding with rmi upgrade...", releaseVersion, upgradeVersion)
 		case upgradeVersion == releaseVersion && helmRelease.Info.Status == release.StatusDeployed:
 			context.Logger.Debugf("%s-%s target version matches release version, skipping upgrade.", RmiChartName, releaseName)
-			return nil
+			skipHelmUpgrade = true
 		default:
 			context.Logger.Infof("%s-%s target version: %s release version/status: %s/%s, starting upgrade.", RmiChartName, releaseName, upgradeVersion, releaseVersion, helmRelease.Info.Status)
 		}
 
-		return a.upgrade(context, cfg, chartURL, releaseName, namespace)
+		return a.upgrade(context, cfg, chartURL, releaseName, namespace, skipHelmUpgrade)
 	case model.OperationTypeDelete:
 		if err == nil {
-			return a.delete(cfg, releaseName)
+			return a.delete(context, cfg, releaseName)
 		}
 	}
 
@@ -141,10 +144,22 @@ func (a *IntegrationAction) install(context *service.ActionContext, cfg *action.
 	}
 
 	setAuthCredetialOverrides(context.Task.Configuration, username, password)
+	a.setPassword(username, password)
 	return nil
 }
 
-func (a *IntegrationAction) upgrade(context *service.ActionContext, cfg *action.Configuration, chartURL, releaseName, namespace string) error {
+func (a *IntegrationAction) upgrade(context *service.ActionContext, cfg *action.Configuration, chartURL, releaseName, namespace string, skipHelmUpgrade bool) error {
+	username := context.Task.Metadata.InstanceID
+	password, err := a.fetchPassword(context.Context, username, releaseName, namespace)
+	if err != nil {
+		return errors.WithMessage(err, "failed to fetch auth credentials from secret")
+	}
+
+	setAuthCredetialOverrides(context.Task.Configuration, username, password)
+
+	if skipHelmUpgrade {
+		return nil
+	}
 
 	upgradeAction := action.NewUpgrade(cfg)
 	upgradeAction.Namespace = namespace
@@ -157,11 +172,6 @@ func (a *IntegrationAction) upgrade(context *service.ActionContext, cfg *action.
 		return errors.Wrapf(err, "while fetching rmi chart from %s", chartURL)
 	}
 
-	username := context.Task.Metadata.InstanceID
-	password, err := a.fetchPasswordFromAuthSecret(context.Context, releaseName, namespace)
-	if err != nil {
-		return errors.WithMessage(err, "failed to fetch auth credentials from secret")
-	}
 	overrides := generateOverrideMap(context, username, password)
 
 	_, err = upgradeAction.Run(releaseName, chart, overrides)
@@ -169,11 +179,10 @@ func (a *IntegrationAction) upgrade(context *service.ActionContext, cfg *action.
 		return errors.WithMessagef(err, "helm upgrade %s-%s failed", RmiChartName, releaseName)
 	}
 
-	setAuthCredetialOverrides(context.Task.Configuration, username, password)
 	return nil
 }
 
-func (a *IntegrationAction) delete(cfg *action.Configuration, releaseName string) error {
+func (a *IntegrationAction) delete(context *service.ActionContext, cfg *action.Configuration, releaseName string) error {
 	uninstallAction := action.NewUninstall(cfg)
 	uninstallAction.Timeout = 5 * time.Minute
 
@@ -182,6 +191,7 @@ func (a *IntegrationAction) delete(cfg *action.Configuration, releaseName string
 		return errors.WithMessagef(err, "helm delete %s-%s failed", RmiChartName, releaseName)
 	}
 
+	a.deletePassword(context.Task.Metadata.InstanceID)
 	return nil
 }
 
@@ -220,32 +230,32 @@ func (a *IntegrationAction) fetchChart(ctx context.Context, chartURL string) (*c
 	return chart, nil
 }
 
-func (a *IntegrationAction) fetchPasswordFromAuthSecret(ctx context.Context, release, namespace string) (string, error) {
-	client, err := a.client.KubernetesClientSet()
-	if err != nil {
-		return "", err
-	}
-	secret, err := client.CoreV1().Secrets(namespace).Get(ctx, fmt.Sprintf("vmuser-%s-%s", RmiChartName, release), metav1.GetOptions{})
-	if err != nil {
-		return "", err
-	}
-	if secret.Data == nil {
-		return "", errors.New("secret data is empty")
-	}
-	password := secret.Data["password"]
-	if len(password) == 0 {
-		return "", errors.New("missing/empty auth credentials")
+func (a *IntegrationAction) fetchPassword(ctx context.Context, username, release, namespace string) (string, error) {
+	a.mux.Lock()
+	defer a.mux.Unlock()
+	password := a.pwds[username]
+
+	if password == "" {
+		client, err := a.client.KubernetesClientSet()
+		if err != nil {
+			return "", err
+		}
+		secret, err := client.CoreV1().Secrets(namespace).Get(ctx, fmt.Sprintf("vmuser-%s-%s", RmiChartName, release), metav1.GetOptions{})
+		if err != nil {
+			return "", err
+		}
+		if secret.Data == nil {
+			return "", errors.New("secret data is empty")
+		}
+		passwordData := secret.Data["password"]
+		if len(passwordData) == 0 {
+			return "", errors.New("missing/empty auth credentials")
+		}
+		password = string(passwordData)
+		a.pwds[username] = password
 	}
 
-	return string(password), nil
-}
-
-func (a *IntegrationAction) getChartVersionFromURL(chartURL string) string {
-	match := a.chartVerExpr.FindStringSubmatch(chartURL)
-	if len(match) < 2 {
-		return ""
-	}
-	return match[1]
+	return password, nil
 }
 
 func generatePassword(n int) (string, error) {
@@ -260,6 +270,26 @@ func generatePassword(n int) (string, error) {
 	}
 
 	return string(ret), nil
+}
+
+func (a *IntegrationAction) setPassword(username, password string) {
+	a.mux.Lock()
+	defer a.mux.Unlock()
+	a.pwds[username] = password
+}
+
+func (a *IntegrationAction) deletePassword(username string) {
+	a.mux.Lock()
+	defer a.mux.Unlock()
+	delete(a.pwds, username)
+}
+
+func (a *IntegrationAction) getChartVersionFromURL(chartURL string) string {
+	match := a.chartVerExpr.FindStringSubmatch(chartURL)
+	if len(match) < 2 {
+		return ""
+	}
+	return match[1]
 }
 
 func generateOverrideMap(context *service.ActionContext, username, password string) map[string]interface{} {


### PR DESCRIPTION
The auth credentials overrides for rma shall be appended by the integration (pre) action regardless whether the RMI is upgraded on the KCP or not. 
To not overload looking up credentials from Secrets upon each reconciliation run of each runtime, the password is cached in memory.