### PR TITLE
fix syntax error in drop commands

### DIFF
--- a/configs/db/postgres/000008_add_operation_retry_id_and_retries.down.sql
+++ b/configs/db/postgres/000008_add_operation_retry_id_and_retries.down.sql
@@ -1,2 +1,2 @@
-ALTER TABLE scheduler_operations DROP COLUMN "retry_id" VARCHAR(255);
-ALTER TABLE scheduler_operations DROP COLUMN "retries" int;
+ALTER TABLE scheduler_operations DROP COLUMN "retry_id";
+ALTER TABLE scheduler_operations DROP COLUMN "retries";


### PR DESCRIPTION
fix syntax error in drop commands caused by #586 