### PR TITLE
No blind mapping

### DIFF
--- a/pkg/cluster/inventory.go
+++ b/pkg/cluster/inventory.go
@@ -399,7 +399,7 @@ func (i *DefaultInventory) latestStatus(configVersion int64) (*model.ClusterStat
 		OrderBy(map[string]string{"ID": "desc"}).
 		GetOne()
 	if err != nil {
-		return nil, i.NewNotFoundError(err, statusEntity, whereCond)
+		return nil, i.MapError(err, statusEntity, whereCond)
 	}
 	return statusEntity.(*model.ClusterStatusEntity), nil
 }
@@ -417,7 +417,7 @@ func (i *DefaultInventory) config(runtimeID string, configVersion int64) (*model
 		Where(whereCond).
 		GetOne()
 	if err != nil {
-		return nil, i.NewNotFoundError(err, configEntity, whereCond)
+		return nil, i.MapError(err, configEntity, whereCond)
 	}
 	return configEntity.(*model.ClusterConfigurationEntity), nil
 }
@@ -435,7 +435,7 @@ func (i *DefaultInventory) latestConfig(clusterVersion int64) (*model.ClusterCon
 		OrderBy(map[string]string{"Version": "desc"}).
 		GetOne()
 	if err != nil {
-		return nil, i.NewNotFoundError(err, configEntity, whereCond)
+		return nil, i.MapError(err, configEntity, whereCond)
 	}
 	return configEntity.(*model.ClusterConfigurationEntity), nil
 }
@@ -453,7 +453,7 @@ func (i *DefaultInventory) cluster(clusterVersion int64) (*model.ClusterEntity, 
 		Where(whereCond).
 		GetOne()
 	if err != nil {
-		return nil, i.NewNotFoundError(err, clusterEntity, whereCond)
+		return nil, i.MapError(err, clusterEntity, whereCond)
 	}
 	return clusterEntity.(*model.ClusterEntity), nil
 }
@@ -474,7 +474,7 @@ func (i *DefaultInventory) latestCluster(runtimeID string) (*model.ClusterEntity
 		}).
 		GetOne()
 	if err != nil {
-		return nil, i.NewNotFoundError(err, clusterEntity, whereCond)
+		return nil, i.MapError(err, clusterEntity, whereCond)
 	}
 	return clusterEntity.(*model.ClusterEntity), nil
 }

--- a/pkg/repository/errors.go
+++ b/pkg/repository/errors.go
@@ -20,10 +20,6 @@ func (r *Repository) NewNotFoundError(err error, entity db.DatabaseEntity,
 func (r *Repository) MapError(err error, entity db.DatabaseEntity, identifier map[string]interface{}) error {
 	if err != sql.ErrNoRows {
 		return err
-	} else if err != sql.ErrTxDone {
-		return err
-	} else if err != sql.ErrConnDone {
-		return err
 	}
 	return &EntityNotFoundError{
 		entity:     entity,

--- a/pkg/repository/errors.go
+++ b/pkg/repository/errors.go
@@ -18,14 +18,14 @@ func (r *Repository) NewNotFoundError(err error, entity db.DatabaseEntity,
 }
 
 func (r *Repository) MapError(err error, entity db.DatabaseEntity, identifier map[string]interface{}) error {
-	if err != sql.ErrNoRows {
-		return err
+	if err == sql.ErrNoRows {
+		return &EntityNotFoundError{
+			entity:     entity,
+			identifier: identifier,
+			err:        err,
+		}
 	}
-	return &EntityNotFoundError{
-		entity:     entity,
-		identifier: identifier,
-		err:        err,
-	}
+	return err
 }
 
 type EntityNotFoundError struct {

--- a/pkg/repository/errors.go
+++ b/pkg/repository/errors.go
@@ -20,6 +20,10 @@ func (r *Repository) NewNotFoundError(err error, entity db.DatabaseEntity,
 func (r *Repository) MapError(err error, entity db.DatabaseEntity, identifier map[string]interface{}) error {
 	if err != sql.ErrNoRows {
 		return err
+	} else if err != sql.ErrTxDone {
+		return err
+	} else if err != sql.ErrConnDone {
+		return err
 	}
 	return &EntityNotFoundError{
 		entity:     entity,


### PR DESCRIPTION
We have to verify the DB errors instead of blindly mapping them to be a `repository.NotFoundError` -  To avoid that the system report `Operation {...} belongs to a no longer existing cluster...` which is obviously not true in many cases. 

This has been adjusted by using the already existing function `MapError` instead of directly mapping to `NotFoundError`.

Since this error log can only be accessed from the outside using RBAC, we can return the sql error.