### PR TITLE
Remove orphaned NATS pods when upgrading Kyma from 1.X to 2.X

### DIFF
--- a/pkg/reconciler/instances/eventing/preaction/fixtures.go
+++ b/pkg/reconciler/instances/eventing/preaction/fixtures.go
@@ -1,0 +1,250 @@
+package preaction
+
+const (
+	manifestString = `
+---
+# Source: nats/templates/00-prereqs.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nats-operator
+  # Change to the name of the namespace where to install NATS Operator.
+  # Alternatively, change to "nats-io" to perform a cluster-scoped deployment in supported versions.
+  namespace: kyma-system
+---
+# Source: nats/templates/00-prereqs.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nats-server
+  namespace: kyma-system
+---
+# Source: nats/templates/00-prereqs.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nats-operator
+rules:
+# Allow creating CRDs
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs: ["get", "list", "create", "update", "watch"]
+
+# Allow all actions on NATS Operator manager CRDs
+- apiGroups:
+  - nats.io
+  resources:
+  - natsclusters
+  - natsserviceroles
+  verbs: ["*"]
+
+# Allowed actions on Pods
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["create", "watch", "get", "patch", "update", "delete", "list"]
+
+# Allowed actions on Services
+- apiGroups: [""]
+  resources:
+  - services
+  verbs: ["create", "watch", "get", "patch", "update", "delete", "list"]
+
+# Allowed actions on Secrets
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs: ["create", "watch", "get", "update", "delete", "list"]
+
+# Allow all actions on some special subresources
+- apiGroups: [""]
+  resources:
+  - pods/exec
+  - pods/log
+  - serviceaccounts/token
+  - events
+  verbs: ["*"]
+
+# Allow listing Namespaces and ServiceAccounts
+- apiGroups: [""]
+  resources:
+  - namespaces
+  - serviceaccounts
+  verbs: ["list", "get", "watch"]
+
+# Allow actions on Endpoints
+- apiGroups: [""]
+  resources:
+  - endpoints
+  verbs: ["create", "watch", "get", "update", "delete", "list"]
+---
+# Source: nats/templates/00-prereqs.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nats-server
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs: ["get"]
+---
+# Source: nats/templates/00-prereqs.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nats-operator-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nats-operator
+subjects:
+- kind: ServiceAccount
+  name: nats-operator
+  # Change to the name of the namespace where to install NATS Operator.
+  # Alternatively, change to "nats-io" to perform a cluster-scoped deployment in supported versions.
+  namespace: kyma-system
+
+# NOTE: When performing multiple namespace-scoped installations, all
+# "nats-operator" service accounts (across the different namespaces)
+# MUST be added to this binding.
+#- kind: ServiceAccount
+#  name: nats-operator
+#  namespace: nats-io
+#- kind: ServiceAccount
+#  name: nats-operator
+#  namespace: namespace-2
+#(...)
+---
+# Source: nats/templates/00-prereqs.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nats-server-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nats-server
+subjects:
+- kind: ServiceAccount
+  name: nats-server
+  namespace: kyma-system
+---
+# Source: nats/templates/20-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: eventing-nats
+  labels: 
+    helm.sh/chart: nats-1.0.0
+    app: nats
+    app.kubernetes.io/managed-by: Helm
+    kyma-project.io/dashboard: eventing
+spec:
+  ports:
+  - name: tcp-client
+    port: 4222
+    targetPort: client
+  selector: 
+    app: nats
+---
+# Source: nats/templates/10-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nats-operator
+  # Change to the name of the namespace where to install NATS Operator.
+  # Alternatively, change to "nats-io" to perform a cluster-scoped deployment in supported versions.
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: nats-operator
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        name: nats-operator
+    spec:
+      serviceAccountName: nats-operator
+      containers:
+      - name: nats-operator
+        image: "eu.gcr.io/kyma-project/nats-operator:c33012c2"
+        imagePullPolicy: "IfNotPresent"
+        args:
+        - nats-operator
+        # Uncomment to perform a cluster-scoped deployment in supported versions.
+        #- --feature-gates=ClusterScoped=true
+        ports:
+        - name: readyz
+          containerPort: 8080
+        env:
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: readyz
+          initialDelaySeconds: 15
+          timeoutSeconds: 3
+---
+# Source: nats/templates/30-destination-rule.yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: eventing-nats
+spec:
+  host: eventing-nats.kyma-system.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: DISABLE
+---
+# Source: nats/templates/40-cr.yaml
+apiVersion: nats.io/v1alpha2
+kind: NatsCluster
+metadata:
+  name: eventing-nats
+spec:
+  size: 1
+  version: "2.1.8"
+  serverImage: "eu.gcr.io/kyma-project/external/nats"
+  pod:
+    annotations:
+      sidecar.istio.io/inject: "false"
+    labels:
+      helm.sh/chart: nats-1.0.0
+      app: nats
+      app.kubernetes.io/managed-by: Helm
+      kyma-project.io/dashboard: eventing
+    resources:
+      limits:
+        cpu: 20m
+        memory: 64Mi
+      requests:
+        cpu: 5m
+        memory: 16Mi
+  natsConfig:
+    debug: true
+    trace: true
+  template:
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    nats_cluster: eventing-nats
+                topologyKey: kubernetes.io/hostname
+              weight: 100
+`
+)

--- a/pkg/reconciler/instances/eventing/preaction/removenatsoperatorstep.go
+++ b/pkg/reconciler/instances/eventing/preaction/removenatsoperatorstep.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"strings"
 
+	v1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
 
 	"go.uber.org/zap"
-	v1 "k8s.io/api/apps/v1"
 
 	"github.com/kyma-incubator/reconciler/pkg/reconciler/chart"
 	"github.com/kyma-incubator/reconciler/pkg/reconciler/instances/eventing/log"
@@ -25,6 +27,7 @@ const (
 	newConfigValue             = "eu.gcr.io/kyma-project"
 	crdPlural                  = "customresourcedefinitions"
 	serviceKind                = "service"
+	podKind                    = "pod"
 )
 
 var (
@@ -63,25 +66,36 @@ func (r *removeNatsOperatorStep) Execute(context *service.ActionContext, logger 
 	//	return nil
 	//}
 
-	kubeClient, err := r.kubeClientProvider(context, logger)
-
-	if err != nil {
-		return err
-	}
-
 	// decorate logger
 	logger = logger.With(log.KeyStep, removeNatsOperatorStepName)
 
-	err = r.removeNatsOperatorResources(context, kubeClient, logger)
+	kubeClient, err := r.kubeClientProvider(context, logger)
 	if err != nil {
 		return err
 	}
 
-	err = r.removeNatsOperatorCRDs(context.Context, kubeClient, logger)
-	return err
+	clientSet, err := kubeClient.Clientset()
+	if err != nil {
+		return err
+	}
+
+	tracker, err := progress.NewProgressTracker(clientSet, logger, progress.Config{Interval: progressTrackerInterval, Timeout: progressTrackerTimeout})
+	if err != nil {
+		return err
+	}
+
+	if err := r.removeNatsOperatorResources(context, kubeClient, logger, tracker); err != nil {
+		return err
+	}
+
+	if err := r.removeNatsOperatorCRDs(context.Context, kubeClient, logger); err != nil {
+		return err
+	}
+
+	return r.removeOrphanedNatsPods(context.Context, kubeClient, logger, tracker)
 }
 
-func (r *removeNatsOperatorStep) removeNatsOperatorResources(context *service.ActionContext, kubeClient kubernetes.Client, logger *zap.SugaredLogger) error {
+func (r *removeNatsOperatorStep) removeNatsOperatorResources(context *service.ActionContext, kubeClient kubernetes.Client, logger *zap.SugaredLogger, tracker *progress.Tracker) error {
 	// get charts from the version 1.2.x, where the NATS-operator resources still exist
 	comp := GetResourcesFromVersion(natsOperatorLastVersion, natsSubChartPath)
 
@@ -92,15 +106,6 @@ func (r *removeNatsOperatorStep) removeNatsOperatorResources(context *service.Ac
 
 	// set the right eventing name, which went lost after rendering
 	manifest.Manifest = strings.ReplaceAll(manifest.Manifest, natsSubChartPath, eventingNats)
-
-	clientSet, err2 := kubeClient.Clientset()
-	if err2 != nil {
-		return err2
-	}
-	tracker, err := progress.NewProgressTracker(clientSet, logger, progress.Config{Interval: progressTrackerInterval, Timeout: progressTrackerTimeout})
-	if err != nil {
-		return err
-	}
 
 	logger.Info("Removing nats-operator chart resources")
 
@@ -179,4 +184,56 @@ func getStatefulSet(context *service.ActionContext, kubeClient kubernetes.Client
 		return nil, nil
 	}
 	return nil, err
+}
+
+// removeOrphanedNatsPods removes orphaned NATS pods if any.
+func (r *removeNatsOperatorStep) removeOrphanedNatsPods(context context.Context, kubeClient kubernetes.Client, logger *zap.SugaredLogger, tracker *progress.Tracker) error {
+	logger.Info("Removing orphaned NATS pods")
+
+	resources, err := kubeClient.ListResource(context, podKind, metav1.ListOptions{LabelSelector: getNatsPodLabelSelector()})
+	if err != nil && errors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if resources == nil || len(resources.Items) == 0 {
+		return nil
+	}
+
+	for _, resource := range resources.Items {
+		if watchable, err := progress.NewWatchableResource(resource.GetKind()); err != nil {
+			logger.Infof("Cannot add the resource kind: %s, name: %s to watchables", resource.GetKind(), resource.GetName())
+		} else {
+			tracker.AddResource(watchable, namespace, resource.GetName())
+		}
+
+		logger.Infof("Deleting: kind: %s, name: %s, namespace: %s", resource.GetKind(), resource.GetName(), namespace)
+		if _, err := kubeClient.DeleteResource(context, resource.GetKind(), resource.GetName(), namespace); err != nil {
+			return err
+		}
+	}
+
+	// wait until all orphaned NATS pods are deleted
+	if err := tracker.Watch(context, progress.TerminatedState); err != nil {
+		logger.Warnf("Watching progress of deleted resources failed: %s", err)
+		return err
+	}
+
+	return nil
+}
+
+// getNatsPodSelectorLabels returns a comma separated string for the NATS pod selector labels.
+func getNatsPodLabelSelector() string {
+	labels := getNatsPodLabels()
+	return k8slabels.SelectorFromSet(labels).String()
+}
+
+// getNatsPodLabels returns a map of NATS pod labels.
+func getNatsPodLabels() map[string]string {
+	return map[string]string{
+		"app":                          "nats",
+		"nats_cluster":                 "eventing-nats",
+		"app.kubernetes.io/managed-by": "Helm",
+	}
 }

--- a/pkg/reconciler/instances/eventing/preaction/removenatsoperatorstep.go
+++ b/pkg/reconciler/instances/eventing/preaction/removenatsoperatorstep.go
@@ -55,16 +55,7 @@ func defaultKubeClientProvider(context *service.ActionContext, logger *zap.Sugar
 }
 
 func (r *removeNatsOperatorStep) Execute(context *service.ActionContext, logger *zap.SugaredLogger) error {
-	// todo skip the step for kyma 2.x+ version for that use the check which will be implemented as a follow-up for https://github.com/kyma-incubator/reconciler/issues/334
-	// no kyma 2.x+ clusters contain nats-operator resources
-	//clusterVersion, err := cluster.Version()
-	//if err != nil {
-	//	return err
-	//}
-	//if clusterVersion > 1 {
-	//	logger.With(log.KeyReason, "NATS-operator resources do not exist on clusters with kyma 2.x+ version").Info("Step skipped")
-	//	return nil
-	//}
+	// TODO skip this step for Kyma 2.X when the following issue is done https://github.com/kyma-incubator/reconciler/issues/334
 
 	// decorate logger
 	logger = logger.With(log.KeyStep, removeNatsOperatorStepName)

--- a/pkg/reconciler/instances/eventing/preaction/removenatsoperatorstep_test.go
+++ b/pkg/reconciler/instances/eventing/preaction/removenatsoperatorstep_test.go
@@ -23,29 +23,21 @@ import (
 	"github.com/kyma-incubator/reconciler/pkg/reconciler/service"
 )
 
-const (
-	manifestString = "---\n# Source: nats/templates/00-prereqs.yaml\napiVersion: v1\nkind: ServiceAccount\nmetadata:\n  name: nats-operator\n  # Change to the name of the namespace where to install NATS Operator.\n  # Alternatively, change to \"nats-io\" to perform a cluster-scoped deployment in supported versions.\n  namespace: kyma-system\n---\n# Source: nats/templates/00-prereqs.yaml\napiVersion: v1\nkind: ServiceAccount\nmetadata:\n  name: nats-server\n  namespace: kyma-system\n---\n# Source: nats/templates/00-prereqs.yaml\napiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRole\nmetadata:\n  name: nats-operator\nrules:\n# Allow creating CRDs\n- apiGroups:\n  - apiextensions.k8s.io\n  resources:\n  - customresourcedefinitions\n  verbs: [\"get\", \"list\", \"create\", \"update\", \"watch\"]\n\n# Allow all actions on NATS Operator manager CRDs\n- apiGroups:\n  - nats.io\n  resources:\n  - natsclusters\n  - natsserviceroles\n  verbs: [\"*\"]\n\n# Allowed actions on Pods\n- apiGroups: [\"\"]\n  resources:\n  - pods\n  verbs: [\"create\", \"watch\", \"get\", \"patch\", \"update\", \"delete\", \"list\"]\n\n# Allowed actions on Services\n- apiGroups: [\"\"]\n  resources:\n  - services\n  verbs: [\"create\", \"watch\", \"get\", \"patch\", \"update\", \"delete\", \"list\"]\n\n# Allowed actions on Secrets\n- apiGroups: [\"\"]\n  resources:\n  - secrets\n  verbs: [\"create\", \"watch\", \"get\", \"update\", \"delete\", \"list\"]\n\n# Allow all actions on some special subresources\n- apiGroups: [\"\"]\n  resources:\n  - pods/exec\n  - pods/log\n  - serviceaccounts/token\n  - events\n  verbs: [\"*\"]\n\n# Allow listing Namespaces and ServiceAccounts\n- apiGroups: [\"\"]\n  resources:\n  - namespaces\n  - serviceaccounts\n  verbs: [\"list\", \"get\", \"watch\"]\n\n# Allow actions on Endpoints\n- apiGroups: [\"\"]\n  resources:\n  - endpoints\n  verbs: [\"create\", \"watch\", \"get\", \"update\", \"delete\", \"list\"]\n---\n# Source: nats/templates/00-prereqs.yaml\napiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRole\nmetadata:\n  name: nats-server\nrules:\n- apiGroups: [\"\"]\n  resources:\n  - nodes\n  verbs: [\"get\"]\n---\n# Source: nats/templates/00-prereqs.yaml\napiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRoleBinding\nmetadata:\n  name: nats-operator-binding\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n  kind: ClusterRole\n  name: nats-operator\nsubjects:\n- kind: ServiceAccount\n  name: nats-operator\n  # Change to the name of the namespace where to install NATS Operator.\n  # Alternatively, change to \"nats-io\" to perform a cluster-scoped deployment in supported versions.\n  namespace: kyma-system\n\n# NOTE: When performing multiple namespace-scoped installations, all\n# \"nats-operator\" service accounts (across the different namespaces)\n# MUST be added to this binding.\n#- kind: ServiceAccount\n#  name: nats-operator\n#  namespace: nats-io\n#- kind: ServiceAccount\n#  name: nats-operator\n#  namespace: namespace-2\n#(...)\n---\n# Source: nats/templates/00-prereqs.yaml\napiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRoleBinding\nmetadata:\n  name: nats-server-binding\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n  kind: ClusterRole\n  name: nats-server\nsubjects:\n- kind: ServiceAccount\n  name: nats-server\n  namespace: kyma-system\n---\n# Source: nats/templates/20-service.yaml\napiVersion: v1\nkind: Service\nmetadata:\n  name: eventing-nats\n  labels: \n    helm.sh/chart: nats-1.0.0\n    app: nats\n    app.kubernetes.io/managed-by: Helm\n    kyma-project.io/dashboard: eventing\nspec:\n  ports:\n  - name: tcp-client\n    port: 4222\n    targetPort: client\n  selector: \n    app: nats\n---\n# Source: nats/templates/10-deployment.yaml\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: nats-operator\n  # Change to the name of the namespace where to install NATS Operator.\n  # Alternatively, change to \"nats-io\" to perform a cluster-scoped deployment in supported versions.\nspec:\n  replicas: 1\n  selector:\n    matchLabels:\n      name: nats-operator\n  template:\n    metadata:\n      annotations:\n        sidecar.istio.io/inject: \"false\"\n      labels:\n        name: nats-operator\n    spec:\n      serviceAccountName: nats-operator\n      containers:\n      - name: nats-operator\n        image: \"eu.gcr.io/kyma-project/nats-operator:c33012c2\"\n        imagePullPolicy: \"IfNotPresent\"\n        args:\n        - nats-operator\n        # Uncomment to perform a cluster-scoped deployment in supported versions.\n        #- --feature-gates=ClusterScoped=true\n        ports:\n        - name: readyz\n          containerPort: 8080\n        env:\n        - name: MY_POD_NAMESPACE\n          valueFrom:\n            fieldRef:\n              fieldPath: metadata.namespace\n        - name: MY_POD_NAME\n          valueFrom:\n            fieldRef:\n              fieldPath: metadata.name\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: readyz\n          initialDelaySeconds: 15\n          timeoutSeconds: 3\n---\n# Source: nats/templates/30-destination-rule.yaml\napiVersion: networking.istio.io/v1alpha3\nkind: DestinationRule\nmetadata:\n  name: eventing-nats\nspec:\n  host: eventing-nats.kyma-system.svc.cluster.local\n  trafficPolicy:\n    tls:\n      mode: DISABLE\n---\n# Source: nats/templates/40-cr.yaml\napiVersion: nats.io/v1alpha2\nkind: NatsCluster\nmetadata:\n  name: eventing-nats\nspec:\n  size: 1\n  version: \"2.1.8\"\n  serverImage: \"eu.gcr.io/kyma-project/external/nats\"\n  pod:\n    annotations:\n      sidecar.istio.io/inject: \"false\"\n    labels:\n      helm.sh/chart: nats-1.0.0\n      app: nats\n      app.kubernetes.io/managed-by: Helm\n      kyma-project.io/dashboard: eventing\n    resources:\n      limits:\n        cpu: 20m\n        memory: 64Mi\n      requests:\n        cpu: 5m\n        memory: 16Mi\n  natsConfig:\n    debug: true\n    trace: true\n  template:\n    spec:\n      affinity:\n        podAntiAffinity:\n          preferredDuringSchedulingIgnoredDuringExecution:\n            - podAffinityTerm:\n                labelSelector:\n                  matchLabels:\n                    nats_cluster: eventing-nats\n                topologyKey: kubernetes.io/hostname\n              weight: 100\n"
-	//kyma1xVersion  = "1.24.8"
-	//kyma2xVersion  = "2.0"
-
-	natsPodNameFormat = "nats-%d"
-)
-
-var testCases = []struct {
-	givenStatefulSet    bool
-	givenNatsPodsLength int
-}{
-	{
-		givenStatefulSet:    true,
-		givenNatsPodsLength: 0,
-	},
-	{
-		givenStatefulSet:    false,
-		givenNatsPodsLength: 3,
-	},
-}
-
 func TestDeletingNatsOperatorResources(t *testing.T) {
+	var testCases = []struct {
+		givenStatefulSet    bool // used to simulate Kyma 2.X Eventing
+		givenNatsPodsLength int  // used to simulate orphaned NATS pods from Kyma 1.X
+	}{
+		{
+			givenStatefulSet:    true,
+			givenNatsPodsLength: 0,
+		},
+		{
+			givenStatefulSet:    false,
+			givenNatsPodsLength: 3,
+		},
+	}
+
 	for _, tc := range testCases {
 		action, actionContext, mockProvider, k8sClient, mockedComponentBuilder, natsPods, err := testSetup(tc.givenStatefulSet, tc.givenNatsPodsLength)
 		require.NoError(t, err)
@@ -147,6 +139,7 @@ func testSetup(givenStatefulSet bool, givenNatsPodsLength int) (*removeNatsOpera
 }
 
 func unstructuredNatsPods(length int) *unstructured.UnstructuredList {
+	const natsPodNameFormat = "nats-%d"
 	instances := make([]unstructured.Unstructured, length)
 	for i := 0; i < length; i++ {
 		instances[i].Object = map[string]interface{}{

--- a/pkg/reconciler/instances/eventing/preaction/removenatsoperatorstep_test.go
+++ b/pkg/reconciler/instances/eventing/preaction/removenatsoperatorstep_test.go
@@ -28,12 +28,24 @@ func TestDeletingNatsOperatorResources(t *testing.T) {
 		givenStatefulSet    bool // used to simulate Kyma 2.X Eventing
 		givenNatsPodsLength int  // used to simulate orphaned NATS pods from Kyma 1.X
 	}{
+		// simulate reconciling Kyma 1.X clusters without orphaned NATS pods
+		{
+			givenStatefulSet:    false,
+			givenNatsPodsLength: 0,
+		},
+		// simulate reconciling Kyma 1.X clusters with orphaned NATS pods
+		{
+			givenStatefulSet:    false,
+			givenNatsPodsLength: 3,
+		},
+		// simulate reconciling Kyma 2.X clusters without orphaned NATS pods
 		{
 			givenStatefulSet:    true,
 			givenNatsPodsLength: 0,
 		},
+		// simulate reconciling Kyma 2.X clusters with orphaned NATS pods
 		{
-			givenStatefulSet:    false,
+			givenStatefulSet:    true,
 			givenNatsPodsLength: 3,
 		},
 	}

--- a/pkg/reconciler/instances/eventing/preaction/removenatsoperatorstep_test.go
+++ b/pkg/reconciler/instances/eventing/preaction/removenatsoperatorstep_test.go
@@ -2,22 +2,24 @@ package preaction
 
 import (
 	"context"
-	pmock "github.com/kyma-incubator/reconciler/pkg/reconciler/chart/mocks"
-	"github.com/kyma-incubator/reconciler/pkg/reconciler/kubernetes"
-	"go.uber.org/zap"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
+	"fmt"
 	"strings"
 	"testing"
 
 	v1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes/fake"
 
-	"github.com/kyma-incubator/reconciler/pkg/reconciler/kubernetes/mocks"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	"github.com/kyma-incubator/reconciler/pkg/logger"
 	"github.com/kyma-incubator/reconciler/pkg/reconciler"
 	"github.com/kyma-incubator/reconciler/pkg/reconciler/chart"
+	pmock "github.com/kyma-incubator/reconciler/pkg/reconciler/chart/mocks"
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/kubernetes"
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/kubernetes/mocks"
 	"github.com/kyma-incubator/reconciler/pkg/reconciler/service"
 )
 
@@ -25,41 +27,55 @@ const (
 	manifestString = "---\n# Source: nats/templates/00-prereqs.yaml\napiVersion: v1\nkind: ServiceAccount\nmetadata:\n  name: nats-operator\n  # Change to the name of the namespace where to install NATS Operator.\n  # Alternatively, change to \"nats-io\" to perform a cluster-scoped deployment in supported versions.\n  namespace: kyma-system\n---\n# Source: nats/templates/00-prereqs.yaml\napiVersion: v1\nkind: ServiceAccount\nmetadata:\n  name: nats-server\n  namespace: kyma-system\n---\n# Source: nats/templates/00-prereqs.yaml\napiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRole\nmetadata:\n  name: nats-operator\nrules:\n# Allow creating CRDs\n- apiGroups:\n  - apiextensions.k8s.io\n  resources:\n  - customresourcedefinitions\n  verbs: [\"get\", \"list\", \"create\", \"update\", \"watch\"]\n\n# Allow all actions on NATS Operator manager CRDs\n- apiGroups:\n  - nats.io\n  resources:\n  - natsclusters\n  - natsserviceroles\n  verbs: [\"*\"]\n\n# Allowed actions on Pods\n- apiGroups: [\"\"]\n  resources:\n  - pods\n  verbs: [\"create\", \"watch\", \"get\", \"patch\", \"update\", \"delete\", \"list\"]\n\n# Allowed actions on Services\n- apiGroups: [\"\"]\n  resources:\n  - services\n  verbs: [\"create\", \"watch\", \"get\", \"patch\", \"update\", \"delete\", \"list\"]\n\n# Allowed actions on Secrets\n- apiGroups: [\"\"]\n  resources:\n  - secrets\n  verbs: [\"create\", \"watch\", \"get\", \"update\", \"delete\", \"list\"]\n\n# Allow all actions on some special subresources\n- apiGroups: [\"\"]\n  resources:\n  - pods/exec\n  - pods/log\n  - serviceaccounts/token\n  - events\n  verbs: [\"*\"]\n\n# Allow listing Namespaces and ServiceAccounts\n- apiGroups: [\"\"]\n  resources:\n  - namespaces\n  - serviceaccounts\n  verbs: [\"list\", \"get\", \"watch\"]\n\n# Allow actions on Endpoints\n- apiGroups: [\"\"]\n  resources:\n  - endpoints\n  verbs: [\"create\", \"watch\", \"get\", \"update\", \"delete\", \"list\"]\n---\n# Source: nats/templates/00-prereqs.yaml\napiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRole\nmetadata:\n  name: nats-server\nrules:\n- apiGroups: [\"\"]\n  resources:\n  - nodes\n  verbs: [\"get\"]\n---\n# Source: nats/templates/00-prereqs.yaml\napiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRoleBinding\nmetadata:\n  name: nats-operator-binding\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n  kind: ClusterRole\n  name: nats-operator\nsubjects:\n- kind: ServiceAccount\n  name: nats-operator\n  # Change to the name of the namespace where to install NATS Operator.\n  # Alternatively, change to \"nats-io\" to perform a cluster-scoped deployment in supported versions.\n  namespace: kyma-system\n\n# NOTE: When performing multiple namespace-scoped installations, all\n# \"nats-operator\" service accounts (across the different namespaces)\n# MUST be added to this binding.\n#- kind: ServiceAccount\n#  name: nats-operator\n#  namespace: nats-io\n#- kind: ServiceAccount\n#  name: nats-operator\n#  namespace: namespace-2\n#(...)\n---\n# Source: nats/templates/00-prereqs.yaml\napiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRoleBinding\nmetadata:\n  name: nats-server-binding\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n  kind: ClusterRole\n  name: nats-server\nsubjects:\n- kind: ServiceAccount\n  name: nats-server\n  namespace: kyma-system\n---\n# Source: nats/templates/20-service.yaml\napiVersion: v1\nkind: Service\nmetadata:\n  name: eventing-nats\n  labels: \n    helm.sh/chart: nats-1.0.0\n    app: nats\n    app.kubernetes.io/managed-by: Helm\n    kyma-project.io/dashboard: eventing\nspec:\n  ports:\n  - name: tcp-client\n    port: 4222\n    targetPort: client\n  selector: \n    app: nats\n---\n# Source: nats/templates/10-deployment.yaml\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: nats-operator\n  # Change to the name of the namespace where to install NATS Operator.\n  # Alternatively, change to \"nats-io\" to perform a cluster-scoped deployment in supported versions.\nspec:\n  replicas: 1\n  selector:\n    matchLabels:\n      name: nats-operator\n  template:\n    metadata:\n      annotations:\n        sidecar.istio.io/inject: \"false\"\n      labels:\n        name: nats-operator\n    spec:\n      serviceAccountName: nats-operator\n      containers:\n      - name: nats-operator\n        image: \"eu.gcr.io/kyma-project/nats-operator:c33012c2\"\n        imagePullPolicy: \"IfNotPresent\"\n        args:\n        - nats-operator\n        # Uncomment to perform a cluster-scoped deployment in supported versions.\n        #- --feature-gates=ClusterScoped=true\n        ports:\n        - name: readyz\n          containerPort: 8080\n        env:\n        - name: MY_POD_NAMESPACE\n          valueFrom:\n            fieldRef:\n              fieldPath: metadata.namespace\n        - name: MY_POD_NAME\n          valueFrom:\n            fieldRef:\n              fieldPath: metadata.name\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: readyz\n          initialDelaySeconds: 15\n          timeoutSeconds: 3\n---\n# Source: nats/templates/30-destination-rule.yaml\napiVersion: networking.istio.io/v1alpha3\nkind: DestinationRule\nmetadata:\n  name: eventing-nats\nspec:\n  host: eventing-nats.kyma-system.svc.cluster.local\n  trafficPolicy:\n    tls:\n      mode: DISABLE\n---\n# Source: nats/templates/40-cr.yaml\napiVersion: nats.io/v1alpha2\nkind: NatsCluster\nmetadata:\n  name: eventing-nats\nspec:\n  size: 1\n  version: \"2.1.8\"\n  serverImage: \"eu.gcr.io/kyma-project/external/nats\"\n  pod:\n    annotations:\n      sidecar.istio.io/inject: \"false\"\n    labels:\n      helm.sh/chart: nats-1.0.0\n      app: nats\n      app.kubernetes.io/managed-by: Helm\n      kyma-project.io/dashboard: eventing\n    resources:\n      limits:\n        cpu: 20m\n        memory: 64Mi\n      requests:\n        cpu: 5m\n        memory: 16Mi\n  natsConfig:\n    debug: true\n    trace: true\n  template:\n    spec:\n      affinity:\n        podAntiAffinity:\n          preferredDuringSchedulingIgnoredDuringExecution:\n            - podAffinityTerm:\n                labelSelector:\n                  matchLabels:\n                    nats_cluster: eventing-nats\n                topologyKey: kubernetes.io/hostname\n              weight: 100\n"
 	//kyma1xVersion  = "1.24.8"
 	//kyma2xVersion  = "2.0"
+
+	natsPodNameFormat = "nats-%d"
 )
 
 var testCases = []struct {
-	givenStatefulSet bool
+	givenStatefulSet    bool
+	givenNatsPodsLength int
 }{
 	{
-		givenStatefulSet: true,
+		givenStatefulSet:    true,
+		givenNatsPodsLength: 0,
 	},
 	{
-		givenStatefulSet: false,
+		givenStatefulSet:    false,
+		givenNatsPodsLength: 3,
 	},
 }
 
 func TestDeletingNatsOperatorResources(t *testing.T) {
-	for _, testCase := range testCases {
-		action, actionContext, mockProvider, k8sClient, mockedComponentBuilder := testSetup(testCase.givenStatefulSet)
+	for _, tc := range testCases {
+		action, actionContext, mockProvider, k8sClient, mockedComponentBuilder, natsPods, err := testSetup(tc.givenStatefulSet, tc.givenNatsPodsLength)
+		require.NoError(t, err)
+
 		// execute the step
-		err := action.Execute(actionContext, actionContext.Logger)
+		err = action.Execute(actionContext, actionContext.Logger)
 		require.NoError(t, err)
 
 		// ensure the right calls were invoked
 		mockProvider.AssertCalled(t, "RenderManifest", mockedComponentBuilder)
 		m := []byte(manifestString)
-		unstructs, err := kubernetes.ToUnstructured(m, true)
+		us, err := kubernetes.ToUnstructured(m, true)
 		require.NoError(t, err)
-		for _, u := range unstructs {
-			if testCase.givenStatefulSet && u.GetName() == eventingNats && strings.EqualFold(u.GetKind(), serviceKind) {
+		for _, u := range us {
+			if tc.givenStatefulSet && u.GetName() == eventingNats && strings.EqualFold(u.GetKind(), serviceKind) {
 				k8sClient.AssertNotCalled(t, "DeleteResource", actionContext.Context, u.GetKind(), u.GetName(), namespace)
 				continue
 			}
 			k8sClient.AssertCalled(t, "DeleteResource", actionContext.Context, u.GetKind(), u.GetName(), namespace)
 		}
+		deletedNatsPodsLength := 0
+		for _, pod := range natsPods.Items {
+			if k8sClient.AssertCalled(t, "DeleteResource", actionContext.Context, pod.GetKind(), pod.GetName(), namespace) {
+				deletedNatsPodsLength++
+			}
+		}
 		k8sClient.AssertCalled(t, "DeleteResource", actionContext.Context, crdPlural, natsOperatorCRDsToDelete[0], namespace)
 		k8sClient.AssertCalled(t, "DeleteResource", actionContext.Context, crdPlural, natsOperatorCRDsToDelete[1], namespace)
 		k8sClient.AssertCalled(t, "GetStatefulSet", actionContext.Context, eventingNats, namespace)
+		require.Equal(t, tc.givenNatsPodsLength, deletedNatsPodsLength)
 	}
 }
 
@@ -77,69 +93,71 @@ func TestDeletingNatsOperatorResources(t *testing.T) {
 //	k8sClient.AssertNotCalled(t, "DeleteResource", mock.Anything, mock.Anything, mock.Anything)
 //}
 
-func testSetup(givenStatefulSet bool) (removeNatsOperatorStep, *service.ActionContext, *pmock.Provider, *mocks.Client, *chart.Component) {
+func testSetup(givenStatefulSet bool, givenNatsPodsLength int) (*removeNatsOperatorStep, *service.ActionContext, *pmock.Provider, *mocks.Client, *chart.Component, *unstructured.UnstructuredList, error) {
 	ctx := context.TODO()
-	k8sClient := mocks.Client{}
-	log := logger.NewLogger(false)
 
-	mockProvider := pmock.Provider{}
-	mockManifest := chart.Manifest{
-		Manifest: manifestString,
+	var statefulSet *v1.StatefulSet
+	if givenStatefulSet {
+		statefulSet = &v1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: eventingNats, Namespace: namespace}}
 	}
+
+	natsPods := unstructuredNatsPods(givenNatsPodsLength)
+
+	// setup mock client
+	k8sClient := mocks.Client{}
+
+	resources, err := kubernetes.ToUnstructured([]byte(manifestString), true)
+	if err != nil {
+		return nil, nil, nil, nil, nil, nil, err
+	}
+	for _, resource := range resources {
+		k8sClient.On("DeleteResource", ctx, resource.GetKind(), resource.GetName(), namespace).Return(nil, nil)
+	}
+
+	for _, natsPod := range natsPods.Items {
+		k8sClient.On("DeleteResource", ctx, natsPod.GetKind(), natsPod.GetName(), namespace).Return(nil, nil)
+	}
+
+	k8sClient.On("Clientset").Return(fake.NewSimpleClientset(), nil)
+	k8sClient.On("GetStatefulSet", ctx, eventingNats, namespace).Return(statefulSet, nil)
+	k8sClient.On("DeleteResource", ctx, crdPlural, natsOperatorCRDsToDelete[0], namespace).Return(nil, nil)
+	k8sClient.On("DeleteResource", ctx, crdPlural, natsOperatorCRDsToDelete[1], namespace).Return(nil, nil)
+	k8sClient.On("ListResource", ctx, podKind, metav1.ListOptions{LabelSelector: getNatsPodLabelSelector()}).Return(natsPods, nil)
+
 	action := removeNatsOperatorStep{
 		kubeClientProvider: func(context *service.ActionContext, logger *zap.SugaredLogger) (kubernetes.Client, error) {
 			return &k8sClient, nil
 		},
 	}
+
+	mockProvider := pmock.Provider{}
+	mockManifest := chart.Manifest{Manifest: manifestString}
 	mockedComponentBuilder := GetResourcesFromVersion(natsOperatorLastVersion, natsSubChartPath)
 	mockProvider.On("RenderManifest", mockedComponentBuilder).Return(&mockManifest, nil)
 
-	var statefulSet *v1.StatefulSet
-	if givenStatefulSet {
-		statefulSet = &v1.StatefulSet{
-			ObjectMeta: metav1.ObjectMeta{Name: eventingNats, Namespace: namespace},
-		}
-	}
-
-	// mock the delete-calls
-	k8sClient.On("Clientset").Return(fake.NewSimpleClientset(), nil)
-	m := []byte(manifestString)
-	resources, _ := kubernetes.ToUnstructured(m, true)
-	for _, resource := range resources {
-		k8sClient.On(
-			"DeleteResource",
-			ctx,
-			resource.GetKind(),
-			resource.GetName(),
-			namespace,
-		).Return(nil, nil)
-	}
-	k8sClient.On(
-		"GetStatefulSet",
-		ctx,
-		eventingNats,
-		namespace,
-	).Return(statefulSet, nil)
-	k8sClient.On(
-		"DeleteResource",
-		ctx,
-		crdPlural,
-		natsOperatorCRDsToDelete[0],
-		namespace,
-	).Return(nil, nil)
-	k8sClient.On(
-		"DeleteResource",
-		ctx,
-		crdPlural,
-		natsOperatorCRDsToDelete[1],
-		namespace,
-	).Return(nil, nil)
-
 	actionContext := &service.ActionContext{
 		Context:       ctx,
-		Logger:        log,
+		Logger:        logger.NewLogger(false),
+		KubeClient:    &k8sClient,
 		ChartProvider: &mockProvider,
 		Task:          &reconciler.Task{},
 	}
-	return action, actionContext, &mockProvider, &k8sClient, mockedComponentBuilder
+
+	return &action, actionContext, &mockProvider, &k8sClient, mockedComponentBuilder, natsPods, nil
+}
+
+func unstructuredNatsPods(length int) *unstructured.UnstructuredList {
+	instances := make([]unstructured.Unstructured, length)
+	for i := 0; i < length; i++ {
+		instances[i].Object = map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name":      fmt.Sprintf(natsPodNameFormat, i),
+				"namespace": namespace,
+				"labels":    getNatsPodLabels(),
+			},
+		}
+	}
+	return &unstructured.UnstructuredList{Items: instances}
 }


### PR DESCRIPTION
**Description**

Sometimes nats-operator fails to remove NATS pods during Kyma upgrade from version 1.X to 2.X, which fails the upgrade process.

This pull request introduces a fix in the Eventing component reconciler (as a pre-action step) by removing orphaned NATS pods when upgrading Kyma from version 1.X to 2.X.

> Note: Image bump is done as part of https://github.com/kyma-project/control-plane/pull/1300.