### PR TITLE
Drop CR finalizers

### DIFF
--- a/pkg/reconciler/instances/cleaner/action.go
+++ b/pkg/reconciler/instances/cleaner/action.go
@@ -1,9 +1,20 @@
 package cleaner
 
 import (
+	"fmt"
+
 	"github.com/kyma-incubator/reconciler/pkg/model"
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/chart"
 	"github.com/kyma-incubator/reconciler/pkg/reconciler/instances/cleaner/pkg/cleanup"
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/kubernetes"
 	"github.com/kyma-incubator/reconciler/pkg/reconciler/service"
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const (
+	deleteStrategyConfigKey = "delete_strategy"
 )
 
 type CleanupAction struct {
@@ -23,10 +34,110 @@ func (a *CleanupAction) Run(context *service.ActionContext) error {
 	context.Logger.Infof("Action '%s' executed: passed version was '%s', passed type was %s", a.name, context.Task.Version, context.Task.Type)
 
 	namespaces := []string{"kyma-system", "kyma-integration"}
-	cliCleaner, err := cleanup.NewCliCleaner(context.Task.Kubeconfig, namespaces, context.Logger)
+
+	var kymaCRDsFinder cleanup.KymaCRDsFinder = func() ([]schema.GroupVersionResource, error) {
+		crdManifests, err := context.ChartProvider.RenderCRD(context.Task.Version)
+		if err != nil {
+			return nil, err
+		}
+		return findKymaCRDs(crdManifests, context.Logger)
+	}
+
+	dropFinalizersOnlyForKymaCRs := readDeleteStrategy(context.Task.Configuration) != "all"
+	cliCleaner, err := cleanup.NewCliCleaner(context.Task.Kubeconfig, namespaces, context.Logger, dropFinalizersOnlyForKymaCRs, kymaCRDsFinder)
 	if err != nil {
 		return err
 	}
 
 	return cliCleaner.Run()
+}
+
+func findKymaCRDs(crdManifests []*chart.Manifest, logger *zap.SugaredLogger) ([]schema.GroupVersionResource, error) {
+	res := []schema.GroupVersionResource{}
+
+	for _, crdManifest := range crdManifests {
+		unstructs, _ := kubernetes.ToUnstructured([]byte(crdManifest.Manifest), true)
+		for _, crdUnstruct := range unstructs {
+
+			crdName := crdUnstruct.GetName()
+			crdObject := crdUnstruct.Object
+
+			group, ok, err := unstructured.NestedString(crdObject, "spec", "group")
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				return nil, fmt.Errorf("Error getting attribute \"spec.group\" for %s CRD", crdName)
+			}
+
+			namesPlural, ok, err := unstructured.NestedString(crdObject, "spec", "names", "plural")
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				return nil, fmt.Errorf("Error getting attribute \"spec.names.plural\" for %s CRD", crdName)
+			}
+
+			versions, versionsFound, err := unstructured.NestedSlice(crdObject, "spec", "versions")
+			if err != nil {
+				return nil, err
+			}
+			if versionsFound {
+				for i, v := range versions {
+					version, ok := v.(map[string]interface{})
+					if !ok {
+						return nil, fmt.Errorf("Error converting attribute \"spec.versions[%d]\" to map for %s CRD", i, crdName)
+					}
+
+					versionName, ok, err := unstructured.NestedString(version, "name")
+					if err != nil {
+						return nil, err
+					}
+					if !ok {
+						return nil, fmt.Errorf("Error getting attribute \"spec.versions[%d].name\" for %s CRD", i, crdName)
+					}
+					grv := toGRV(group, versionName, namesPlural)
+					logger.Debugf("Found Kyma CRD: %s.%s/%s", grv.Resource, grv.Group, grv.Version)
+					res = append(res, grv)
+				}
+			} else {
+				//No "spec.versions" attribute, look for "spec.version"
+				versionName, versionOK, err := unstructured.NestedString(crdObject, "spec", "version") //deprecated attribute existing in `apiextensions.k8s.io/v1beta1`
+				if err != nil {
+					return nil, err
+				}
+				if !versionOK {
+					return nil, fmt.Errorf("Can't find neither \"spec.versions\" nor \"spec.version\" for %s CRD", crdName)
+				}
+				grv := toGRV(group, versionName, namesPlural)
+				logger.Debugf("Found Kyma CRD: %s.%s/%s", grv.Resource, grv.Group, grv.Version)
+				res = append(res, grv)
+			}
+		}
+	}
+
+	return res, nil
+}
+
+func toGRV(group, version, resource string) schema.GroupVersionResource {
+
+	return schema.GroupVersionResource{
+		Group:    group,
+		Version:  version,
+		Resource: resource,
+	}
+}
+
+func readDeleteStrategy(config map[string]interface{}) string {
+	v := config[deleteStrategyConfigKey]
+	if v == nil {
+		return ""
+	}
+
+	s, ok := v.(string)
+	if !ok {
+		return ""
+	}
+
+	return s
 }

--- a/pkg/reconciler/instances/cleaner/action.go
+++ b/pkg/reconciler/instances/cleaner/action.go
@@ -27,11 +27,11 @@ func (a *CleanupAction) Run(context *service.ActionContext) error {
 		return nil
 	}
 
+	context.Logger.Infof("Action '%s' executed: passed version was '%s', passed type was %s", a.name, context.Task.Version, context.Task.Type)
+
 	if _, err := context.KubeClient.Clientset(); err != nil { //cleaner how to retrieve native Kubernetes GO client
 		return err
 	}
-
-	context.Logger.Infof("Action '%s' executed: passed version was '%s', passed type was %s", a.name, context.Task.Version, context.Task.Type)
 
 	namespaces := []string{"kyma-system", "kyma-integration"}
 

--- a/pkg/reconciler/instances/cleaner/pkg/cleanup/crd.go
+++ b/pkg/reconciler/instances/cleaner/pkg/cleanup/crd.go
@@ -1,0 +1,150 @@
+package cleanup
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	apierr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8sRetry "k8s.io/client-go/util/retry"
+)
+
+func (cmd *CliCleaner) removeCustomResourcesFinalizers() error {
+	crds := map[string]schema.GroupVersionResource{}
+
+	if cmd.dropFinalizersOnlyForKymaCRs {
+		cmd.logger.Info("Removing finalizers only for custom resources installed by Kyma")
+
+		kymaCRDs, err := cmd.kymaCRDsFinder()
+		if err != nil {
+			return err
+		}
+
+		crManagedByReconciler, err := cmd.findCRDsByLabel(crLabelReconciler)
+		if err != nil {
+			return err
+		}
+
+		crManagedByIstio, err := cmd.findCRDsByLabel(crLabelIstio)
+		if err != nil {
+			return err
+		}
+
+		appendCRDs(crds, kymaCRDs)
+		appendCRDs(crds, crManagedByReconciler) //In case current sources doesn't contain Kyma CRD that exist on the cluster (consider upgrades)
+		appendCRDs(crds, crManagedByIstio)      //Istio CRD is NOT in Kyma sources
+	} else {
+		cmd.logger.Info("Removing existing finalizers for all custom resources in the cluster")
+
+		allClusterCRDs, err := cmd.findAllCRDsInCluster()
+		if err != nil {
+			return err
+		}
+		appendCRDs(crds, allClusterCRDs)
+	}
+
+	var lastErr error
+	for key, crdef := range crds {
+		err := cmd.removeFinalizersFromAllInstancesOf(crdef) //Continue in case of an error
+		if err != nil {
+			lastErr = err
+			cmd.logger.Infof("Error while dropping finalizers for CustomResourceDefinition \"%s\": %s", key, err.Error())
+		}
+	}
+
+	return lastErr //return last error (if any)
+}
+
+func (cmd *CliCleaner) findAllCRDsInCluster() ([]schema.GroupVersionResource, error) {
+	return cmd.findCRDsByLabel("")
+}
+
+func (cmd *CliCleaner) findCRDsByLabel(label string) ([]schema.GroupVersionResource, error) {
+	res := []schema.GroupVersionResource{}
+
+	crds, err := cmd.apixClient.CustomResourceDefinitions().List(context.Background(), metav1.ListOptions{LabelSelector: label})
+	if err != nil && !apierr.IsNotFound(err) {
+		return nil, err
+	}
+
+	if crds == nil {
+		return res, nil
+	}
+
+	for _, crd := range crds.Items {
+		crdef := schema.GroupVersionResource{
+			Group:    crd.Spec.Group,
+			Version:  crd.Spec.Version,
+			Resource: crd.Spec.Names.Plural,
+		}
+		res = append(res, crdef)
+	}
+
+	return res, nil
+}
+
+func (cmd *CliCleaner) removeFinalizersFromAllInstancesOf(crdef schema.GroupVersionResource) error {
+	cmd.logger.Infof("Dropping finalizers for all custom resources of type: %s.%s/%s", crdef.Resource, crdef.Group, crdef.Version)
+	defer cmd.logger.Infof("Finished dropping finalizers for custom resources of type: %s.%s/%s", crdef.Resource, crdef.Group, crdef.Version)
+
+	customResourceList, err := cmd.k8s.Dynamic().Resource(crdef).Namespace(v1.NamespaceAll).List(context.Background(), metav1.ListOptions{})
+	if err != nil && !apierr.IsNotFound(err) {
+		return err
+	}
+
+	if customResourceList == nil {
+		return nil
+	}
+
+	for i := range customResourceList.Items {
+		instance := customResourceList.Items[i]
+		retryErr := k8sRetry.RetryOnConflict(k8sRetry.DefaultRetry, func() error { return cmd.removeCustomResourceFinalizers(crdef, instance) })
+		if retryErr != nil {
+			return errors.Wrapf(retryErr, "deleting finalizer for %s.%s/%s \"%s\" failed:", crdef.Resource, crdef.Group, crdef.Version, instance.GetName())
+		}
+	}
+
+	return nil
+}
+
+func (cmd *CliCleaner) removeCustomResourceFinalizers(crdef schema.GroupVersionResource, instance unstructured.Unstructured) error {
+	// Retrieve the latest version of Custom Resource before attempting update
+	// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
+	res, err := cmd.k8s.Dynamic().Resource(crdef).Namespace(instance.GetNamespace()).Get(context.Background(), instance.GetName(), metav1.GetOptions{})
+	if err != nil && !apierr.IsNotFound(err) {
+		return err
+	}
+	if res == nil {
+		return nil
+	}
+
+	if len(res.GetFinalizers()) > 0 {
+		cmd.logger.Infof("Found finalizers for \"%s\" %s, deleting", res.GetName(), instance.GetKind())
+
+		res.SetFinalizers(nil)
+		_, err := cmd.k8s.Dynamic().Resource(crdef).Namespace(res.GetNamespace()).Update(context.Background(), res, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+
+		cmd.logger.Infof("Deleted finalizer for \"%s\" %s", res.GetName(), instance.GetKind())
+	}
+
+	if !cmd.keepCRDs {
+		err = cmd.k8s.Dynamic().Resource(crdef).Namespace(res.GetNamespace()).Delete(context.Background(), res.GetName(), metav1.DeleteOptions{})
+		if err != nil && !apierr.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func appendCRDs(m map[string]schema.GroupVersionResource, list []schema.GroupVersionResource) {
+	for _, gvr := range list {
+		key := gvr.Resource + "." + gvr.Group + "/" + gvr.Version
+		m[key] = gvr
+	}
+}


### PR DESCRIPTION
**Description**

This PR extends logic for dropping Custom Resource finalizers. Such finalizers may, in certain conditions, block cluster deprovisioning.

There are two modes of operation (already added to kyma-cli)
- "system": Drop only finalizers from Custom Resource instances of types (CustomResourceDefinitions) introduced with Kyma 
- "all": Drop finalizers from all Custom Resource instances found in the cluster.

Both modes operate on all namespaces.
For "system" mode, the logic collects CRDs from Kyma sources (i.e. from Kyma charts), then adds CRDs from the cluster labelled with `reconciler.kyma-project.io/managed-by=reconciler`, then adds Istio CRDs. This set of CRDs is then used to find all existing CR instances.