### PR TITLE
Fix memory leak in RMA integration action

### DIFF
--- a/pkg/reconciler/instances/rma/integration_action.go
+++ b/pkg/reconciler/instances/rma/integration_action.go
@@ -71,7 +71,7 @@ func (a *IntegrationAction) Run(context *service.ActionContext) error {
 	}
 	releaseName := context.Task.Metadata.ShootName
 
-	cfg, err := a.client.HelmActionConfiguration(namespace, context.Logger.Debugf)
+	cfg, err := a.client.HelmActionConfiguration(namespace)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In RMA reconciler we are affected by a [known bug](https://github.com/helm/helm/issues/10374) in helm action package when it's used as an API SDK rather than a CLI functionality.
This PR works around the memory leak by using cached helm action configuration per namespace.

![profile004](https://user-images.githubusercontent.com/11090449/151156772-f8a6cc35-3e43-4a95-9381-647e81e6f77b.png)
