### PR TITLE
formatted component reconcilers names to fit metric label validation

### DIFF
--- a/cmd/mothership/mothership/start/scheduler.go
+++ b/cmd/mothership/mothership/start/scheduler.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/kyma-incubator/reconciler/pkg/logger"
@@ -58,7 +59,8 @@ func startScheduler(ctx context.Context, o *Options, schedulerCfg *config.Config
 func getListOfReconcilers(cfg *config.Config) []string {
 	reconcilerList := make([]string, 0, len(cfg.Scheduler.Reconcilers)+1)
 	for reconName := range cfg.Scheduler.Reconcilers {
-		reconcilerList = append(reconcilerList, reconName)
+		formattedReconName := strings.Replace(reconName, "-", "_", -1)
+		reconcilerList = append(reconcilerList, formattedReconName)
 	}
 	return append(reconcilerList, "mothership")
 }


### PR DESCRIPTION

**Changes in this PR**
- formatted component reconcilers names to fit metric label validation
**Reason**
Upon testing with more component reconcilers, I found that Prometheus wasn't accepting some component reconcilers names as a metric label.