### PR TITLE
Revert debug logging on istio reconciler

### DIFF
--- a/pkg/reconciler/instances/istio/istio.go
+++ b/pkg/reconciler/instances/istio/istio.go
@@ -18,7 +18,7 @@ const (
 //nolint:gochecknoinits //usage of init() is intended to register reconciler-instances in centralized registry
 func init() {
 
-	log := logger.NewLogger(true)
+	log := logger.NewLogger(false)
 
 	log.Debugf("Initializing component reconciler '%s'", ReconcilerNameIstio)
 	reconcilerIstio, err := service.NewComponentReconciler(ReconcilerNameIstio)


### PR DESCRIPTION
Debug messages for istio reconciler show now on init (e.g. every time a CLI command runs)