### PR TITLE
Load Istio target version from values.yaml instead of Chart.yaml

### DIFF
--- a/pkg/reconciler/instances/istio/actions/performer.go
+++ b/pkg/reconciler/instances/istio/actions/performer.go
@@ -310,13 +310,13 @@ func getTargetVersionFromPilotInChartValues(workspace chart.Factory, branch stri
 		return "", err
 	}
 
-	mapAsJson, err := json.Marshal(helmChart.Values)
+	mapAsJSON, err := json.Marshal(helmChart.Values)
 	if err != nil {
 		return "", err
 	}
 
 	var chartValues chartValues
-	err = json.Unmarshal(mapAsJson, &chartValues)
+	err = json.Unmarshal(mapAsJSON, &chartValues)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/reconciler/instances/istio/actions/performer.go
+++ b/pkg/reconciler/instances/istio/actions/performer.go
@@ -310,12 +310,14 @@ func getTargetVersionFromPilotInChartValues(workspace chart.Factory, branch stri
 		return "", err
 	}
 
-	mapAsJson, err := json.Marshal(helmChart.Values); if err != nil {
+	mapAsJson, err := json.Marshal(helmChart.Values)
+	if err != nil {
 		return "", err
 	}
 
 	var chartValues chartValues
-	err = json.Unmarshal(mapAsJson, &chartValues); if err != nil {
+	err = json.Unmarshal(mapAsJson, &chartValues)
+	if err != nil {
 		return "", err
 	}
 

--- a/pkg/reconciler/instances/istio/actions/performer_test.go
+++ b/pkg/reconciler/instances/istio/actions/performer_test.go
@@ -499,7 +499,7 @@ func Test_DefaultIstioPerformer_Version(t *testing.T) {
 		ver, err := wrapper.Version(factory, "version", "istio-test", kubeConfig, log)
 
 		// then
-		require.EqualValues(t, IstioStatus{ClientVersion: "1.11.2", TargetVersion: "1.11.2"}, ver)
+		require.EqualValues(t, IstioStatus{ClientVersion: "1.11.2", TargetVersion: "1.2.3-solo-fips-distroless"}, ver)
 		require.NoError(t, err)
 		cmder.AssertCalled(t, "Version", mock.AnythingOfType("string"), mock.AnythingOfType("*zap.SugaredLogger"))
 		cmder.AssertNumberOfCalls(t, "Version", 1)
@@ -520,14 +520,14 @@ func Test_DefaultIstioPerformer_Version(t *testing.T) {
 		ver, err := wrapper.Version(factory, "version", "istio-test", kubeConfig, log)
 
 		// then
-		require.EqualValues(t, IstioStatus{ClientVersion: "1.11.1", TargetVersion: "1.11.2", PilotVersion: "1.11.1", DataPlaneVersion: "1.11.1"}, ver)
+		require.EqualValues(t, IstioStatus{ClientVersion: "1.11.1", TargetVersion: "1.2.3-solo-fips-distroless", PilotVersion: "1.11.1", DataPlaneVersion: "1.11.1"}, ver)
 		require.NoError(t, err)
 		cmder.AssertCalled(t, "Version", mock.AnythingOfType("string"), mock.AnythingOfType("*zap.SugaredLogger"))
 		cmder.AssertNumberOfCalls(t, "Version", 1)
 	})
 }
 
-func TestGetTargetVersionFromChart(t *testing.T) {
+func Test_getTargetVersionFromPilotInChartValues(t *testing.T) {
 	branch := "branch"
 
 	t.Run("should not get target version when the workspace is not resolved", func(t *testing.T) {
@@ -537,7 +537,7 @@ func TestGetTargetVersionFromChart(t *testing.T) {
 		factory.On("Get", mock.AnythingOfType("string")).Return(&chart.KymaWorkspace{}, nil)
 
 		// when
-		_, err := getTargetVersionFromChart(factory, branch, istioChart)
+		_, err := getTargetVersionFromPilotInChartValues(factory, branch, istioChart)
 
 		// then
 		require.Error(t, err)
@@ -551,25 +551,25 @@ func TestGetTargetVersionFromChart(t *testing.T) {
 		factory.On("Get", mock.AnythingOfType("string")).Return(&chart.KymaWorkspace{ResourceDir: "../test_files"}, nil)
 
 		// when
-		_, err := getTargetVersionFromChart(factory, branch, istioChart)
+		_, err := getTargetVersionFromPilotInChartValues(factory, branch, istioChart)
 
 		// then
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "no such file or directory")
 	})
 
-	t.Run("should get target version when Chart.yml is resolved", func(t *testing.T) {
+	t.Run("should get target version when values.yaml file is resolved", func(t *testing.T) {
 		// given
 		istioChart := "istio-test"
 		factory := &workspacemocks.Factory{}
 		factory.On("Get", mock.AnythingOfType("string")).Return(&chart.KymaWorkspace{ResourceDir: "../test_files"}, nil)
 
 		// when
-		targetVersion, err := getTargetVersionFromChart(factory, branch, istioChart)
+		targetVersion, err := getTargetVersionFromPilotInChartValues(factory, branch, istioChart)
 
 		// then
 		require.NoError(t, err)
-		require.EqualValues(t, "1.11.2", targetVersion)
+		require.EqualValues(t, "1.2.3-solo-fips-distroless", targetVersion)
 	})
 }
 

--- a/pkg/reconciler/instances/istio/istio_test.go
+++ b/pkg/reconciler/instances/istio/istio_test.go
@@ -194,7 +194,7 @@ func Test_RunUpdateAction(t *testing.T) {
 		err := action.Run(actionContext)
 
 		// then
-		require.EqualError(t, err, "Istio could not be updated since the binary version: 1.09.2 is not compatible with the target version: 1.11.2 - the difference between versions exceeds one minor version")
+		require.EqualError(t, err, "Istio could not be updated since the binary version: 1.09.2 is not compatible with the target version: 1.11.2-solo-fips-distroless - the difference between versions exceeds one minor version")
 		commanderMock.AssertCalled(t, "Version", mock.Anything, mock.Anything)
 		commanderMock.AssertNotCalled(t, "Upgrade", mock.Anything, mock.Anything, mock.Anything)
 	})

--- a/pkg/reconciler/instances/istio/test_files/0.0.0/resources/istio-configuration/values.yaml
+++ b/pkg/reconciler/instances/istio/test_files/0.0.0/resources/istio-configuration/values.yaml
@@ -1,0 +1,6 @@
+---
+
+global:
+  images:
+    istio_pilot:
+      version: "1.1.0-solo-fips-distroless"

--- a/pkg/reconciler/instances/istio/test_files/1.11.2/resources/istio-configuration/values.yaml
+++ b/pkg/reconciler/instances/istio/test_files/1.11.2/resources/istio-configuration/values.yaml
@@ -1,0 +1,6 @@
+---
+
+global:
+  images:
+    istio_pilot:
+      version: "1.11.2-solo-fips-distroless"

--- a/pkg/reconciler/instances/istio/test_files/istio-test/values.yaml
+++ b/pkg/reconciler/instances/istio/test_files/istio-test/values.yaml
@@ -1,0 +1,6 @@
+---
+
+global:
+  images:
+    istio_pilot:
+      version: "1.2.3-solo-fips-distroless"


### PR DESCRIPTION
### Description

Suggested changes:
- remove loading Istio target version from Chart.yaml
- load Istio target version from values.yaml
- fix tests

### Links
See: https://github.com/kyma-incubator/reconciler/issues/744