### PR TITLE
Bookkeeper: reduce retry count for deletion

### DIFF
--- a/pkg/scheduler/service/bookkeeper.go
+++ b/pkg/scheduler/service/bookkeeper.go
@@ -21,13 +21,15 @@ const (
 	//send a heartbeat message for such operations before the bookkeeper starts running and marks them as orphan.
 	defaultOperationsWatchInterval = 45 * time.Second
 	defaultOrphanOperationTimeout  = 10 * time.Minute
-	defaultMaxRetries              = 150
+	defaultMaxReconcileErrRetries  = 150
+	defaultMaxDeleteErrRetries     = 15
 )
 
 type BookkeeperConfig struct {
 	OperationsWatchInterval time.Duration
 	OrphanOperationTimeout  time.Duration
-	MaxRetries              int
+	MaxReconcileErrRetries  int
+	MaxDeleteErrRetries     int
 }
 
 func (wc *BookkeeperConfig) validate() error {
@@ -43,11 +45,17 @@ func (wc *BookkeeperConfig) validate() error {
 	if wc.OrphanOperationTimeout == 0 {
 		wc.OrphanOperationTimeout = defaultOrphanOperationTimeout
 	}
-	if wc.MaxRetries < 0 {
-		return errors.New("maxRetries cannot be < 0")
+	if wc.MaxReconcileErrRetries < 0 {
+		return errors.New("maxReconcileErrRetries cannot be < 0")
 	}
-	if wc.MaxRetries == 0 {
-		wc.MaxRetries = defaultMaxRetries
+	if wc.MaxReconcileErrRetries == 0 {
+		wc.MaxReconcileErrRetries = defaultMaxReconcileErrRetries
+	}
+	if wc.MaxDeleteErrRetries < 0 {
+		return errors.New("maxDeleteErrRetries cannot be < 0")
+	}
+	if wc.MaxDeleteErrRetries == 0 {
+		wc.MaxDeleteErrRetries = defaultMaxDeleteErrRetries
 	}
 	return nil
 }

--- a/pkg/scheduler/service/bookkeepingtask.go
+++ b/pkg/scheduler/service/bookkeepingtask.go
@@ -2,10 +2,11 @@ package service
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/kyma-incubator/reconciler/pkg/model"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
-	"time"
 )
 
 type BookkeepingTask interface {
@@ -47,21 +48,21 @@ func (fo finishOperation) Apply(reconResult *ReconciliationResult, config *Bookk
 	newClusterStatus := reconResult.GetResult()
 
 	if newClusterStatus == model.ClusterStatusDeleteError {
-		errCnt, err := fo.transition.inventory.CountRetries(reconResult.reconEntity.RuntimeID, reconResult.reconEntity.ClusterConfig, config.MaxRetries, model.ClusterStatusDeleteError, model.ClusterStatusDeleteErrorRetryable)
+		errCnt, err := fo.transition.inventory.CountRetries(reconResult.reconEntity.RuntimeID, reconResult.reconEntity.ClusterConfig, config.MaxDeleteErrRetries, model.ClusterStatusDeleteError, model.ClusterStatusDeleteErrorRetryable)
 		if err != nil {
 			fo.logger.Error(err)
 		}
-		if errCnt < config.MaxRetries {
+		if errCnt < config.MaxDeleteErrRetries {
 			newClusterStatus = model.ClusterStatusDeleteErrorRetryable
 			fo.logger.Infof("Deletion for cluster with runtimeID %s and clusterConfig %d failed, deletion "+
 				"will be retried. Count of retries: %d", reconResult.reconEntity.RuntimeID, reconResult.reconEntity.ClusterConfig, errCnt)
 		}
 	} else if newClusterStatus == model.ClusterStatusReconcileError {
-		errCnt, err := fo.transition.inventory.CountRetries(reconResult.reconEntity.RuntimeID, reconResult.reconEntity.ClusterConfig, config.MaxRetries, model.ClusterStatusReconcileError, model.ClusterStatusReconcileErrorRetryable)
+		errCnt, err := fo.transition.inventory.CountRetries(reconResult.reconEntity.RuntimeID, reconResult.reconEntity.ClusterConfig, config.MaxReconcileErrRetries, model.ClusterStatusReconcileError, model.ClusterStatusReconcileErrorRetryable)
 		if err != nil {
 			fo.logger.Error(err)
 		}
-		if errCnt < config.MaxRetries {
+		if errCnt < config.MaxReconcileErrRetries {
 			newClusterStatus = model.ClusterStatusReconcileErrorRetryable
 			fo.logger.Infof("Reconciliation for cluster with runtimeID '%s' and clusterConfig '%d' failed but "+
 				"reconciliation will be retried (count of applied retries: %d)",

--- a/pkg/scheduler/service/bookkeepingtask_test.go
+++ b/pkg/scheduler/service/bookkeepingtask_test.go
@@ -84,7 +84,7 @@ func TestBookkeepingTask(t *testing.T) {
 				&BookkeeperConfig{
 					OperationsWatchInterval: 100 * time.Millisecond,
 					OrphanOperationTimeout:  1 * time.Microsecond,
-					MaxRetries:              150,
+					MaxReconcileErrRetries:  150,
 				},
 				logger.NewLogger(true),
 			)
@@ -205,7 +205,7 @@ func TestBookkeepingTaskParallel(t *testing.T) {
 				&BookkeeperConfig{
 					OperationsWatchInterval: 100 * time.Millisecond,
 					OrphanOperationTimeout:  1 * time.Microsecond,
-					MaxRetries:              150,
+					MaxReconcileErrRetries:  150,
 				},
 				logger.NewLogger(true),
 			)


### PR DESCRIPTION
**Description**

Add ability to configure cluster deletion retries separately from cluster reconcilation retries.
Retries for deletion are by default 10 times smaller (15) than default retries for reconcilation (150)

See: https://github.com/kyma-incubator/reconciler/issues/775
