### PR TITLE
Set task type from operation instead of cluster state

### DIFF
--- a/pkg/scheduler/invoker/invoker.go
+++ b/pkg/scheduler/invoker/invoker.go
@@ -22,6 +22,7 @@ type Params struct {
 	SchedulingID         string
 	CorrelationID        string
 	MaxOperationRetries  int
+	Type                 model.OperationType
 }
 
 func (p *Params) newLocalTask(callbackFunc func(msg *reconciler.CallbackMessage) error) *reconciler.Task {
@@ -52,11 +53,6 @@ func (p *Params) newTask() *reconciler.Task {
 		tokenNamespace = ""
 	}
 
-	taskType := model.OperationTypeReconcile
-	if p.ClusterState.Status.Status.IsDeletion() {
-		taskType = model.OperationTypeDelete
-	}
-
 	return &reconciler.Task{
 		ComponentsReady: p.ComponentsReady,
 		Component:       p.ComponentToReconcile.Component,
@@ -72,7 +68,7 @@ func (p *Params) newTask() *reconciler.Task {
 			URL:            url,
 			TokenNamespace: fmt.Sprint(tokenNamespace),
 		},
-		Type: taskType,
+		Type: p.Type,
 		ComponentConfiguration: reconciler.ComponentConfiguration{
 			MaxRetries: p.MaxOperationRetries,
 		},

--- a/pkg/scheduler/invoker/invoker_test.go
+++ b/pkg/scheduler/invoker/invoker_test.go
@@ -4,33 +4,35 @@ import (
 	"testing"
 
 	"github.com/kyma-incubator/reconciler/pkg/keb"
+	"github.com/kyma-incubator/reconciler/pkg/model"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestInvoker(t *testing.T) {
-	t.Run("Should parse repo token namespace correctly", func(t *testing.T) {
-		params := Params{
-			ComponentToReconcile: &keb.Component{
-				URL:       "",
-				Component: "",
-				Configuration: []keb.Configuration{
-					{
-						Key:    "repo.token.namespace",
-						Secret: false,
-						Value:  nil,
-					},
-				},
-				Namespace: "",
-				Version:   "",
-			},
-			ComponentsReady:     nil,
-			ClusterState:        clusterStateMock,
-			SchedulingID:        "",
-			CorrelationID:       "",
-			MaxOperationRetries: 0,
-		}
 
-		model := params.newTask()
-		assert.Equal(t, "", model.Repository.TokenNamespace)
-	})
+	params := Params{
+		ComponentToReconcile: &keb.Component{
+			URL:       "",
+			Component: "",
+			Configuration: []keb.Configuration{
+				{
+					Key:    "repo.token.namespace",
+					Secret: false,
+					Value:  nil,
+				},
+			},
+			Namespace: "",
+			Version:   "",
+		},
+		ComponentsReady:     nil,
+		ClusterState:        clusterStateMock,
+		SchedulingID:        "",
+		CorrelationID:       "",
+		MaxOperationRetries: 0,
+		Type:                model.OperationTypeDelete,
+	}
+
+	task := params.newTask()
+	assert.Equal(t, "", task.Repository.TokenNamespace, "Should parse repo token namespace correctly")
+	assert.Equal(t, model.OperationTypeDelete, task.Type, "Task type should equal operation type")
 }

--- a/pkg/scheduler/invoker/localinvoker_test.go
+++ b/pkg/scheduler/invoker/localinvoker_test.go
@@ -29,7 +29,7 @@ func (a *unittestReconcileAction) Run(_ *service.ActionContext) error {
 }
 
 func TestLocalInvoker(t *testing.T) {
-	test.IntegrationTest(t)
+	//test.IntegrationTest(t)
 
 	t.Run("Run local reconciler: successfully finished reconciliation", func(t *testing.T) {
 		reconRepo, opEntity := runLocalReconciler(t, false)
@@ -89,6 +89,7 @@ func runLocalReconciler(t *testing.T, simulateError bool) (reconciliation.Reposi
 		SchedulingID:        opEntity.SchedulingID,
 		CorrelationID:       opEntity.CorrelationID,
 		MaxOperationRetries: 5,
+		Type:                opEntity.Type,
 	})
 
 	if simulateError {

--- a/pkg/scheduler/invoker/localinvoker_test.go
+++ b/pkg/scheduler/invoker/localinvoker_test.go
@@ -29,7 +29,7 @@ func (a *unittestReconcileAction) Run(_ *service.ActionContext) error {
 }
 
 func TestLocalInvoker(t *testing.T) {
-	//test.IntegrationTest(t)
+	test.IntegrationTest(t)
 
 	t.Run("Run local reconciler: successfully finished reconciliation", func(t *testing.T) {
 		reconRepo, opEntity := runLocalReconciler(t, false)

--- a/pkg/scheduler/worker/worker.go
+++ b/pkg/scheduler/worker/worker.go
@@ -51,6 +51,7 @@ func (w *worker) run(ctx context.Context, clusterState *cluster.State, op *model
 			CorrelationID:        op.CorrelationID,
 			ClusterState:         clusterState,
 			MaxOperationRetries:  maxOpRetries,
+			Type:                 op.Type,
 		})
 	}
 


### PR DESCRIPTION
**Description**
- Now task type (reconcile/delete) is set from the operation type instead of the cluster state, which may get changed before the operations run.
- Added unit test case to verify that tasks get the type correctly

**Related issues**
#782 was presumably caused by this in a subsequent delete attempt.