### PR TITLE
Hardcode ServiceManager auth URL suffix for sc-migration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/kyma-incubator/reconciler
 go 1.16
 
 require (
-	github.com/SAP/sap-btp-service-operator v0.1.21
+	github.com/SAP/sap-btp-service-operator v0.1.22
 	github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/coreos/go-semver v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/SAP/sap-btp-service-operator v0.1.21 h1:4f7P9g8XYvtZ9AHFayiZmY7TqEZElc4nvdR3rgKhkKo=
-github.com/SAP/sap-btp-service-operator v0.1.21/go.mod h1:l2xMJAjn+6vJ16uzBBFf9NiAqIUKEUvn1cN3tD05AjQ=
+github.com/SAP/sap-btp-service-operator v0.1.22 h1:F9iwVLlassCa8gtZkD46PyO5YLaupKL/io+rwVH87vg=
+github.com/SAP/sap-btp-service-operator v0.1.22/go.mod h1:l2xMJAjn+6vJ16uzBBFf9NiAqIUKEUvn1cN3tD05AjQ=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d h1:UrqY+r/OJnIp5u0s1SbQ8dVfLCZJsnvazdBP5hS4iRs=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=

--- a/pkg/reconciler/instances/scmigration/btp_operator_migration.go
+++ b/pkg/reconciler/instances/scmigration/btp_operator_migration.go
@@ -77,23 +77,23 @@ func newMigrator(ac *service.ActionContext) (*migrator, error) {
 	}
 	secret, err := cs.CoreV1().Secrets(namespace).Get(ctx, "sap-btp-service-operator", metav1.GetOptions{})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get Secret %v/sap-btp-service-operator: %w", namespace, err)
 	}
 	configMap, err := cs.CoreV1().ConfigMaps(namespace).Get(ctx, "sap-btp-operator-config", metav1.GetOptions{})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get ConfigMap %v/sap-btp-operator-config: %w", namespace, err)
 	}
 	smClient, err := getSMClient(ctx, secret)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to instantiate SMClient with secret %v/%v: %w", secret.Namespace, secret.Name, err)
 	}
 	services, err := getServices(smClient)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get SM services: %w", err)
 	}
 	plans, err := getPlans(smClient)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get SM plans: %w", err)
 	}
 	migrator := &migrator{
 		ac:                    ac,

--- a/pkg/reconciler/instances/scmigration/utils.go
+++ b/pkg/reconciler/instances/scmigration/utils.go
@@ -20,11 +20,12 @@ const operatorGroupVersion = "v1alpha1"
 func getSMClient(ctx context.Context, secret *v1.Secret) (sm.Client, error) {
 	secretData := secret.Data
 	return sm.NewClient(ctx, &sm.ClientConfig{
-		ClientID:     string(secretData["clientid"]),
-		ClientSecret: string(secretData["clientsecret"]),
-		URL:          string(secretData["url"]),
-		TokenURL:     string(secretData["tokenurl"]),
-		SSLDisabled:  false,
+		ClientID:       string(secretData["clientid"]),
+		ClientSecret:   string(secretData["clientsecret"]),
+		URL:            string(secretData["url"]),
+		TokenURL:       string(secretData["tokenurl"]),
+		TokenURLSuffix: "/oauth/token",
+		SSLDisabled:    false,
 	}, nil)
 }
 


### PR DESCRIPTION
Older versions of Service Manager client library from BTP operator had this hardcoded internally, newly BTP operator moved the default value to the chart.

https://github.com/SAP/sap-btp-service-operator/pull/48/