### PR TITLE
Leverage heartbeat to send processing Duration instead of own endpoint

### DIFF
--- a/openapi/internal_api.yaml
+++ b/openapi/internal_api.yaml
@@ -52,45 +52,11 @@ paths:
                 $ref: './external_api.yaml#/components/schemas/HTTPErrorResponse'
         '500':
           $ref: './external_api.yaml#/components/responses/InternalError'
-  /operations/{schedulingID}/{correlationID}/processingDuration:
-    post:
-      description: test
-      parameters:
-        - name: schedulingID
-          required: true
-          in: path
-          schema:
-            type: string
-            format: uuid
-        - name: correlationID
-          required: true
-          in: path
-          schema:
-            type: string
-            format: uuid
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/processingDuration'
-      responses:
-        '200':
-          description: "Ok"
-        '400':
-          $ref: './external_api.yaml#/components/responses/BadRequest'
-        '404':
-          description: 'Given operation not found'
-          content:
-            application/json:
-              schema:
-                $ref: './external_api.yaml#/components/schemas/HTTPErrorResponse'
-        '500':
-          $ref: './external_api.yaml#/components/responses/InternalError'
 components:
   schemas:
     callbackMessage:
       type: object
-      required: [ status, error, retryID ]
+      required: [ status, error, retryID, processingDuration ]
       properties:
         status:
           $ref: '#/components/schemas/status'
@@ -99,7 +65,8 @@ components:
         retryID:
           type: string
           format: uuid
-
+        processingDuration:
+          type: integer
     status:
       type: string
       enum:
@@ -108,10 +75,3 @@ components:
         - running
         - success
         - failed
-
-    processingDuration:
-      type: object
-      required: [ duration ]
-      properties:
-        duration:
-          type: integer

--- a/pkg/reconciler/heartbeat/heartbeat_test.go
+++ b/pkg/reconciler/heartbeat/heartbeat_test.go
@@ -98,7 +98,7 @@ func TestHeartbeatSender(t *testing.T) { //DO NOT RUN THIS TEST CASES IN PARALLE
 		require.Equal(t, retryID, callbackHdlr.RetryID())
 		time.Sleep(2 * time.Second)
 
-		require.NoError(t, heartbeatSender.Success(retryID))
+		require.NoError(t, heartbeatSender.Success(retryID, 0))
 		require.Equal(t, heartbeatSender.CurrentStatus(), reconciler.StatusSuccess)
 		require.Equal(t, retryID, callbackHdlr.RetryID())
 		time.Sleep(2 * time.Second)

--- a/pkg/reconciler/model_gen.go
+++ b/pkg/reconciler/model_gen.go
@@ -18,14 +18,10 @@ const (
 
 // CallbackMessage defines model for callbackMessage.
 type CallbackMessage struct {
-	Error   string `json:"error"`
-	RetryID string `json:"retryID"`
-	Status  Status `json:"status"`
-}
-
-// ProcessingDuration defines model for processingDuration.
-type ProcessingDuration struct {
-	Duration int `json:"duration"`
+	Error              string `json:"error"`
+	ProcessingDuration int    `json:"processingDuration"`
+	RetryID            string `json:"retryID"`
+	Status             Status `json:"status"`
 }
 
 // Status defines model for status.
@@ -34,11 +30,5 @@ type Status string
 // PostOperationsSchedulingIDCallbackCorrelationIDJSONBody defines parameters for PostOperationsSchedulingIDCallbackCorrelationID.
 type PostOperationsSchedulingIDCallbackCorrelationIDJSONBody CallbackMessage
 
-// PostOperationsSchedulingIDCorrelationIDProcessingDurationJSONBody defines parameters for PostOperationsSchedulingIDCorrelationIDProcessingDuration.
-type PostOperationsSchedulingIDCorrelationIDProcessingDurationJSONBody ProcessingDuration
-
 // PostOperationsSchedulingIDCallbackCorrelationIDJSONRequestBody defines body for PostOperationsSchedulingIDCallbackCorrelationID for application/json ContentType.
 type PostOperationsSchedulingIDCallbackCorrelationIDJSONRequestBody PostOperationsSchedulingIDCallbackCorrelationIDJSONBody
-
-// PostOperationsSchedulingIDCorrelationIDProcessingDurationJSONRequestBody defines body for PostOperationsSchedulingIDCorrelationIDProcessingDuration for application/json ContentType.
-type PostOperationsSchedulingIDCorrelationIDProcessingDurationJSONRequestBody PostOperationsSchedulingIDCorrelationIDProcessingDurationJSONBody


### PR DESCRIPTION
Instead of updating the processingDuration using an own endpoint, the heartbeat is leveraged to also update it. Thus, we do not have two transaction updating the same row in the scheduler_operations table.

Fixes #836 