### PR TITLE
Fix duplicated order by clause

### DIFF
--- a/pkg/scheduler/reconciliation/filter.go
+++ b/pkg/scheduler/reconciliation/filter.go
@@ -42,6 +42,7 @@ type Limit struct {
 	actualCount int
 }
 
+// TODO: Limit should only apply limit without sorting.
 func (l *Limit) FilterByQuery(q *db.Select) error {
 	q.OrderBy(map[string]string{"Created": "DESC"}).Limit(l.Count)
 	return nil

--- a/pkg/scheduler/reconciliation/inmemory.go
+++ b/pkg/scheduler/reconciliation/inmemory.go
@@ -52,6 +52,7 @@ func (r *InMemoryReconciliationRepository) CreateReconciliation(state *cluster.S
 		ClusterConfig:       state.Configuration.Version,
 		ClusterConfigStatus: state.Status.ID,
 		SchedulingID:        fmt.Sprintf("%s--%s", state.Cluster.RuntimeID, uuid.NewString()),
+		Created:             time.Now().UTC(),
 	}
 	r.reconciliations[state.Cluster.RuntimeID] = reconEntity
 

--- a/pkg/scheduler/reconciliation/persistent.go
+++ b/pkg/scheduler/reconciliation/persistent.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -241,7 +242,11 @@ func (r *PersistentReconciliationRepository) GetReconciliations(filter Filter) (
 			return nil, errors.Wrap(err, "failed to apply sql filter")
 		}
 	}
-	recons, err := selectQ.OrderBy(map[string]string{"Created": "DESC"}).GetMany()
+	// TODO: the ORM should maintain the correct SQL statement order and handle duplicated clauses.
+	if !strings.Contains(selectQ.String(), "ORDER BY") {
+		selectQ = selectQ.OrderBy(map[string]string{"Created": "DESC"})
+	}
+	recons, err := selectQ.GetMany()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scheduler/reconciliation/reconciliation_test.go
+++ b/pkg/scheduler/reconciliation/reconciliation_test.go
@@ -2,11 +2,12 @@ package reconciliation
 
 import (
 	"fmt"
-	"github.com/kyma-incubator/reconciler/pkg/repository"
-	"github.com/pkg/errors"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/kyma-incubator/reconciler/pkg/repository"
+	"github.com/pkg/errors"
 
 	"github.com/google/uuid"
 	"github.com/kyma-incubator/reconciler/pkg/cluster"
@@ -341,6 +342,11 @@ func TestReconciliationRepository(t *testing.T) {
 				recon, err := reconRepo.GetReconciliations(&CurrentlyReconciling{})
 				require.NoError(t, err)
 				require.Len(t, recon, 1)
+				require.Equal(t, reconEntity2.SchedulingID, recon[0].SchedulingID)
+
+				limit, err := reconRepo.GetReconciliations(&Limit{Count: 1})
+				require.NoError(t, err)
+				require.Len(t, limit, 1)
 				require.Equal(t, reconEntity2.SchedulingID, recon[0].SchedulingID)
 			},
 		},


### PR DESCRIPTION
Currently, the `Limit` query filter is applying an `ORDER BY` clause in addition to `LIMIT`. This is causing a SQL syntax error, since `GetReconciliations()` adds another `ORDER BY` clause by default.

Unfortunately, simply removing the order clause from the filter doesn't resolve this, because the end result is also a syntactically incorrect statement. In this case the `LIMIT` clause comes _before_ the `ORDER BY` clause which is incorrect. 

Also, applying the order by clause before the filter will break other queries using different filters. For example, in cases where the query is using a `WHERE` filter, the final query would have an order by clause _before_ the where clause.

This PR implements the least invasive fix to resolve the issue.

https://github.com/kyma-project/control-plane/issues/1307