### PR TITLE
enable pprof for profiling data

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,4 +2,7 @@ repos:
   - repo: local
     hooks:
       - id: lint
-        entry: make lint
+        name: lint
+        language: system
+        entry: make
+        args: [ "lint" ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: local
+    hooks:
+      - id: lint
+        entry: make lint

--- a/cmd/mothership/main.go
+++ b/cmd/mothership/main.go
@@ -13,6 +13,7 @@ import (
 	file "github.com/kyma-incubator/reconciler/pkg/files"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	_ "net/http/pprof"
 )
 
 const (

--- a/cmd/mothership/main.go
+++ b/cmd/mothership/main.go
@@ -13,7 +13,6 @@ import (
 	file "github.com/kyma-incubator/reconciler/pkg/files"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	_ "net/http/pprof"
 )
 
 const (

--- a/cmd/mothership/mothership/start/http.go
+++ b/cmd/mothership/mothership/start/http.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/viper"
+	_ "net/http/pprof"
 )
 
 const (
@@ -53,6 +54,7 @@ func startWebserver(ctx context.Context, o *Options) error {
 	apiRouter := mainRouter.PathPrefix("/").Subrouter()
 	metricsRouter := mainRouter.Path("/metrics").Subrouter()
 	healthRouter := mainRouter.PathPrefix("/health").Subrouter()
+	mainRouter.PathPrefix("/debug/pprof/").Handler(http.DefaultServeMux)
 
 	apiRouter.HandleFunc(
 		fmt.Sprintf("/v{%s}/operations/{%s}/{%s}/stop", paramContractVersion, paramSchedulingID, paramCorrelationID),

--- a/cmd/mothership/mothership/start/http.go
+++ b/cmd/mothership/mothership/start/http.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/viper"
-	_ "net/http/pprof"
 )
 
 const (


### PR DESCRIPTION
To help us better analyze memory usage, and investigate potential memory leaks, it's better to enable pprof https://pkg.go.dev/net/http/pprof

Verify:
With this change, after running mothership locally, you should be able to visit the default debug profiling page under: http://localhost:8080/debug/pprof/