### PR TITLE
Add handleDisableJetstream preaction for disabling the jetstream feature flag

### DIFF
--- a/pkg/reconciler/instances/eventing/preaction/handledisablejetstream.go
+++ b/pkg/reconciler/instances/eventing/preaction/handledisablejetstream.go
@@ -48,9 +48,10 @@ func (r *handleEnablingJetstream) Execute(context *service.ActionContext, logger
 
 	// decorate logger
 	logger = logger.With(log.KeyStep, handleDisableJetstream)
-	jetstreamFlag, err := fetchJetstreamFlag(context, logger)
-	if err != nil {
-		return err
+	jetstreamFlag, errorString := fetchJetstreamFlag(context, logger)
+	if errorString != "" {
+		logger.With(log.KeyReason, errorString).Info("Step skipped")
+		return nil
 	}
 
 	logger.Infof("Jetstream is flag is set to %v", jetstreamFlag)
@@ -78,34 +79,41 @@ func (r *handleEnablingJetstream) Execute(context *service.ActionContext, logger
 }
 
 // fetchJetstreamFlag gets the value of ENABLE_JETSTREAM_BACKEND environment var from the eventing controller deployment.
-func fetchJetstreamFlag(context *service.ActionContext, logger *zap.SugaredLogger) (bool, error) {
+func fetchJetstreamFlag(context *service.ActionContext, logger *zap.SugaredLogger) (bool, string) {
 	comp := GetResourcesFromVersion(chartsVersion, chartsName)
 
 	// get the values from eventing/values.yaml
 	configurationValues, err := context.ChartProvider.Configuration(comp)
 	if err != nil {
-		return false, err
+		return false, err.Error()
 	}
 
 	// the enableJetstreamFlag is stored in .Values.global.features.enableJetstream
 	global := configurationValues["global"].(interface{})
-	globalsJson, err := json.Marshal(global)
+	globalsJSON, err2 := json.Marshal(global)
+	if err2 != nil {
+		return false, err2.Error()
+	}
 
 	// the regex should compile and find the necessary flag
 	re := regexp.MustCompile(enableJetstreamRegExp)
-	if !re.MatchString(string(globalsJson)) {
-		logger.With(log.KeyReason, "Cannot find the jetstream Flag in the eventing helm values").Info("Step skipped")
-		return false, nil
+	if !re.MatchString(string(globalsJSON)) {
+		return false, "Cannot find the jetstream Flag in the eventing helm values"
 	}
 
-	matches := re.FindStringSubmatch(string(globalsJson))
+	matches := re.FindStringSubmatch(string(globalsJSON))
+	// first element of the array should be the whole regexp match
+	// the second - the group match
 	if len(matches) != 2 {
 		logger.With(log.KeyReason, "Cannot find the jetstream Flag in the eventing helm values").Info("Step skipped")
-		return false, nil
+		return false, "Cannot find the jetstream Flag in the eventing helm values"
 	}
 
 	jetstreamFlag, err := strconv.ParseBool(matches[1])
-	return jetstreamFlag, err
+	if err != nil {
+		return false, err.Error()
+	}
+	return jetstreamFlag, ""
 }
 
 // getDeployment returns a Kubernetes deployment given its name.
@@ -120,7 +128,7 @@ func getStatefulSetUsingClientSet(context *service.ActionContext, clientset kube
 	return nil, err
 }
 
-// checkJetstreamData checks if the nats-statefulSet contains the jetstream-related data
+// jetstreamDataExists checks if the nats-statefulSet contains the jetstream-related data.
 func jetstreamDataExists(statefulSet *v1.StatefulSet) bool {
 	for _, container := range statefulSet.Spec.Template.Spec.Containers {
 		if !strings.EqualFold(container.Name, natsContainerName) {

--- a/pkg/reconciler/instances/eventing/preaction/handledisablejetstream.go
+++ b/pkg/reconciler/instances/eventing/preaction/handledisablejetstream.go
@@ -1,0 +1,137 @@
+package preaction
+
+import (
+	"encoding/json"
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/instances/eventing/action"
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/instances/eventing/log"
+	v1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	"go.uber.org/zap"
+
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/service"
+)
+
+const (
+	handleDisableJetstream = "handleEnableJetstream"
+	enableJetstreamRegExp  = `enableJetStream[\\"]*:[\\"]*(true|false)`
+	jsEnabledFlag          = "JS_ENABLED"
+	natsContainerName      = "nats"
+	statefulSetName        = "eventing-nats"
+	chartsVersion          = "main"
+	chartsName             = "eventing"
+)
+
+type handleEnablingJetstream struct{}
+
+var _ action.Step = &handleEnablingJetstream{}
+
+func newHandleEnablingJetstream() *handleEnablingJetstream {
+	return &handleEnablingJetstream{}
+}
+
+// Execute removes the Nats StatefulSet in the cases when the jetstream Flag is disabled
+// but there are still jetstream resources remaining in the StatefulSet.
+func (r *handleEnablingJetstream) Execute(context *service.ActionContext, logger *zap.SugaredLogger) error {
+
+	// prepare Kubernetes clientset
+	clientset, err := context.KubeClient.Clientset()
+	if err != nil {
+		return err
+	}
+
+	// decorate logger
+	logger = logger.With(log.KeyStep, handleDisableJetstream)
+	jetstreamFlag, err := fetchJetstreamFlag(context, logger)
+	if err != nil {
+		return err
+	}
+
+	logger.Infof("Jetstream is flag is set to %v", jetstreamFlag)
+
+	// be sure NO jetstream-related data still remain in the workload if its disabled
+	if !jetstreamFlag {
+		natsStatefulSet, err := getStatefulSetUsingClientSet(context, clientset, statefulSetName)
+		if err != nil {
+			return err
+		}
+		if jetstreamDataExists(natsStatefulSet) {
+			logger.Info("Removing Nats StatefulSet for proper Jetstream uninstallation")
+			err = clientset.AppsV1().StatefulSets(namespace).Delete(context.Context, statefulSetName, metav1.DeleteOptions{})
+			if err != nil {
+				return err
+			}
+		} else {
+			logger.With(log.KeyReason, "No preparations need to be done, no JS").Info("Step skipped")
+		}
+	} else {
+		logger.With(log.KeyReason, "No preparations need to be done").Info("Step skipped")
+	}
+
+	return nil
+}
+
+// fetchJetstreamFlag gets the value of ENABLE_JETSTREAM_BACKEND environment var from the eventing controller deployment.
+func fetchJetstreamFlag(context *service.ActionContext, logger *zap.SugaredLogger) (bool, error) {
+	comp := GetResourcesFromVersion(chartsVersion, chartsName)
+
+	// get the values from eventing/values.yaml
+	configurationValues, err := context.ChartProvider.Configuration(comp)
+	if err != nil {
+		return false, err
+	}
+
+	// the enableJetstreamFlag is stored in .Values.global.features.enableJetstream
+	global := configurationValues["global"].(interface{})
+	globalsJson, err := json.Marshal(global)
+
+	// the regex should compile and find the necessary flag
+	re := regexp.MustCompile(enableJetstreamRegExp)
+	if !re.MatchString(string(globalsJson)) {
+		logger.With(log.KeyReason, "Cannot find the jetstream Flag in the eventing helm values").Info("Step skipped")
+		return false, nil
+	}
+
+	matches := re.FindStringSubmatch(string(globalsJson))
+	if len(matches) != 2 {
+		logger.With(log.KeyReason, "Cannot find the jetstream Flag in the eventing helm values").Info("Step skipped")
+		return false, nil
+	}
+
+	jetstreamFlag, err := strconv.ParseBool(matches[1])
+	return jetstreamFlag, err
+}
+
+// getDeployment returns a Kubernetes deployment given its name.
+func getStatefulSetUsingClientSet(context *service.ActionContext, clientset kubernetes.Interface, name string) (*v1.StatefulSet, error) {
+	statefulSet, err := clientset.AppsV1().StatefulSets(namespace).Get(context.Context, name, metav1.GetOptions{})
+	if err == nil {
+		return statefulSet, nil
+	}
+	if errors.IsNotFound(err) {
+		return nil, nil
+	}
+	return nil, err
+}
+
+// checkJetstreamData checks if the nats-statefulSet contains the jetstream-related data
+func jetstreamDataExists(statefulSet *v1.StatefulSet) bool {
+	for _, container := range statefulSet.Spec.Template.Spec.Containers {
+		if !strings.EqualFold(container.Name, natsContainerName) {
+			continue
+		}
+		for _, env := range container.Env {
+			// JS_ENABLED signatures that js data is still in place
+			if strings.EqualFold(env.Name, jsEnabledFlag) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/reconciler/instances/eventing/preaction/handledisablejetstream_test.go
+++ b/pkg/reconciler/instances/eventing/preaction/handledisablejetstream_test.go
@@ -1,0 +1,135 @@
+package preaction
+
+import (
+	"context"
+	"fmt"
+	"github.com/kyma-incubator/reconciler/pkg/reconciler"
+	pmock "github.com/kyma-incubator/reconciler/pkg/reconciler/chart/mocks"
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/service"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strconv"
+	"testing"
+
+	"github.com/kyma-incubator/reconciler/pkg/logger"
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/kubernetes/mocks"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestRemovingTheStatefulSet(t *testing.T) {
+
+	var testCases = []struct {
+		name                            string
+		givenJetstreamFlag              bool
+		givenJetstreamDataInStatefulSet bool
+		wantStatefulSetDeletion         bool
+	}{
+		{
+			name:                            "When Nats StatefulSet has jetstream data and jetstream is disabled the StatefulSet should remain untouched",
+			givenJetstreamFlag:              true,
+			givenJetstreamDataInStatefulSet: true,
+			wantStatefulSetDeletion:         false,
+		},
+		{
+			name:                            "When Nats StatefulSet has jetstream data but jetstream is disabled the StatefulSet should be deleted",
+			givenJetstreamFlag:              false,
+			givenJetstreamDataInStatefulSet: true,
+			wantStatefulSetDeletion:         true,
+		},
+		{
+			name:                            "When Nats StatefulSet has no jetstream data and jetstream is disabled, the StatefulSet should remain untouched",
+			givenJetstreamFlag:              false,
+			givenJetstreamDataInStatefulSet: false,
+			wantStatefulSetDeletion:         false,
+		},
+		{
+			name:                            "When Nats StatefulSet has jetstream data but jetstream is disabled, the StatefulSet should remain untouched, as the data will be deleted by the reconciler",
+			givenJetstreamFlag:              true,
+			givenJetstreamDataInStatefulSet: false,
+			wantStatefulSetDeletion:         false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			k8sClient, action, actionContext := setup(getHelmEventingValues(tc.givenJetstreamFlag))
+			// given
+			_, err := k8sClient.AppsV1().StatefulSets(namespace).Create(actionContext.Context, createStatefulSet(tc.givenJetstreamDataInStatefulSet), metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			// when
+			err = action.Execute(actionContext, actionContext.Logger)
+			require.NoError(t, err)
+
+			// then
+			gotStatefulSet, err := getStatefulSetUsingClientSet(actionContext, k8sClient, statefulSetName)
+			require.NoError(t, err)
+			if tc.wantStatefulSetDeletion {
+				require.Nil(t, gotStatefulSet)
+			} else {
+				require.NotNil(t, gotStatefulSet)
+			}
+		})
+	}
+}
+
+func setup(chartValues string) (kubernetes.Interface, handleEnablingJetstream, *service.ActionContext) {
+	k8sClient := fake.NewSimpleClientset()
+	action := handleEnablingJetstream{}
+	mockClient := mocks.Client{}
+	mockClient.On("Clientset").Return(k8sClient, nil)
+
+	mockProvider := pmock.Provider{}
+
+	mockConfiguration := map[string]interface{}{
+		"global": chartValues,
+	}
+	mockedComponentBuilder := GetResourcesFromVersion(chartsVersion, chartsName)
+	mockProvider.On("Configuration", mockedComponentBuilder).Return(mockConfiguration, nil)
+
+	// todo mock manifest with chart values
+	actionContext := &service.ActionContext{
+		KubeClient:    &mockClient,
+		Context:       context.TODO(),
+		ChartProvider: &mockProvider,
+		Logger:        logger.NewLogger(false),
+		Task:          &reconciler.Task{Version: "test"},
+	}
+	return k8sClient, action, actionContext
+}
+
+func createStatefulSet(withJestreamData bool) *v1.StatefulSet {
+	var containerEnvs []corev1.EnvVar
+	if withJestreamData {
+		containerEnvs = []corev1.EnvVar{
+			{
+				Name:  "JS_ENABLED",
+				Value: "true",
+			}}
+	}
+	return &v1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      statefulSetName,
+			Namespace: namespace,
+		},
+		Spec: v1.StatefulSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: natsContainerName,
+							Env:  containerEnvs,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func getHelmEventingValues(enableJetstream bool) string {
+	return fmt.Sprintf("{\"configMap\":{\"keys\":{\"eventTypePrefix\":\"eventTypePrefix\"},\"name\":\"eventing\"},\"containerRegistry\":{\"path\":\"eu.gcr.io/kyma-project\"},\"domainName\":\"kyma.example.com\",\"eventTypePrefix\":\"sap.kyma.custom\",\"features\":{\"enableJetStream\":%s},\"image\":{\"repository\":\"eu.gcr.io/kyma-project\"},\"images\":{\"eventing_controller\":{\"name\":\"eventing-controller\",\"pullPolicy\":\"IfNotPresent\",\"version\":\"PR-13464\"},\"nats\":{\"directory\":\"external\",\"name\":\"nats\",\"version\":\"2.6.5-alpine\"},\"publisher_proxy\":{\"name\":\"event-publisher-proxy\",\"version\":\"PR-13469\"}},\"istio\":{\"proxy\":{\"portName\":\"http-status\",\"statusPort\":15020}},\"log\":{\"format\":\"json\",\"level\":\"info\"},\"secretName\":\"\",\"securityContext\":{\"allowPrivilegeEscalation\":false,\"privileged\":false}}", strconv.FormatBool(enableJetstream))
+}

--- a/pkg/reconciler/instances/eventing/preaction/preaction.go
+++ b/pkg/reconciler/instances/eventing/preaction/preaction.go
@@ -14,5 +14,6 @@ func New() *action.Action {
 		// add PreAction steps here
 		newRemoveNatsOperatorStep(),
 		newMigrateEventTypePrefixConfigStep(),
+		newHandleEnablingJetstream(),
 	})
 }


### PR DESCRIPTION
**Description**

There is a `enableJetStream` flag in the eventing helm values which is then used to inject the Jetsream-specific data into the nats ConfigMap, StatefulSet and Pods. There is a problem in the upgrade scenario from `enableJetStream=true` to `enableJetStream=false`, as the JS-related data is not being removed from the statefulSet. 

- [ ] Before merging this PR, another PR https://github.com/kyma-project/kyma/pull/13496 should be merged

**Changes Proposed**
This pr adds a preaction to the eventing component reconciler in order to check this problem and remove the StatefulSet during the upgrade.

**Related Issue**
https://github.com/kyma-project/kyma/issues/13321