### PR TITLE
Add prometheus metrics for scmigration reconciler

### DIFF
--- a/cmd/reconciler/start/service/http.go
+++ b/cmd/reconciler/start/service/http.go
@@ -13,10 +13,15 @@ import (
 	"github.com/kyma-incubator/reconciler/pkg/reconciler/service"
 	"github.com/kyma-incubator/reconciler/pkg/server"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 const (
 	paramContractVersion = "version"
+)
+
+var (
+	EnableMetrics = false
 )
 
 func StartWebserver(ctx context.Context, o *reconCli.Options, workerPool *service.WorkerPool, tracker *service.OccupancyTracker) error {
@@ -42,6 +47,9 @@ func newRouter(ctx context.Context, o *reconCli.Options, workerPool *service.Wor
 	//liveness and readiness checks
 	router.HandleFunc("/health/live", live)
 	router.HandleFunc("/health/ready", ready(workerPool))
+	if EnableMetrics {
+		router.Path("/metrics").Handler(promhttp.Handler())
+	}
 
 	return router
 }

--- a/pkg/reconciler/instances/scmigration/action.go
+++ b/pkg/reconciler/instances/scmigration/action.go
@@ -9,6 +9,7 @@ type reconcileAction struct {
 }
 
 func (a *reconcileAction) Run(ac *service.ActionContext) error {
+	ac.Logger = ac.Logger.With("instanceID", ac.Task.Metadata.InstanceID)
 	if _, err := ac.KubeClient.Clientset(); err != nil {
 		ac.Logger.Errorf("Failed to retrieve native Kubernetes GO client")
 	}

--- a/pkg/reconciler/instances/scmigration/scmigration.go
+++ b/pkg/reconciler/instances/scmigration/scmigration.go
@@ -1,11 +1,79 @@
 package scmigration
 
 import (
+	startservice "github.com/kyma-incubator/reconciler/cmd/reconciler/start/service"
 	"github.com/kyma-incubator/reconciler/pkg/logger"
 	"github.com/kyma-incubator/reconciler/pkg/reconciler/service"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 const ReconcilerName = "sc-migration"
+
+var (
+	migratedInstancesTotal = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "migrated_instances_total",
+			Help: "Migrated instances total",
+		},
+		[]string{"instance_id"},
+	)
+
+	migratedInstancesFailures = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "migrated_instances_failures",
+			Help: "Migrated instances failures",
+		},
+		[]string{"instance_id"},
+	)
+
+	svcatInstancesTotal = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "svcat_instances_total",
+			Help: "Service catalog instances processed total",
+		},
+		[]string{"instance_id"},
+	)
+
+	smInstancesTotal = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "sm_instances_total",
+			Help: "Service manager instances processed total",
+		},
+		[]string{"instance_id"},
+	)
+
+	migratedBindingsTotal = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "migrated_bindings_total",
+			Help: "Migrated bindings total",
+		},
+		[]string{"instance_id"},
+	)
+
+	migratedBindingsFailures = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "migrated_bindings_failures",
+			Help: "Migrated bindings failures",
+		},
+		[]string{"instance_id"},
+	)
+
+	svcatBindingsTotal = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "svcat_bindings_total",
+			Help: "Service catalog bindings processed total",
+		},
+		[]string{"instance_id"},
+	)
+
+	smBindingsTotal = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "sm_bindings_total",
+			Help: "Service manager bindings processed total",
+		},
+		[]string{"instance_id"},
+	)
+)
 
 //nolint:gochecknoinits
 func init() {
@@ -16,6 +84,12 @@ func init() {
 	if err != nil {
 		log.Fatalf("Could not create '%s' component reconciler: %s", ReconcilerName, err)
 	}
-
+	startservice.EnableMetrics = true
+	prometheus.MustRegister(migratedInstancesTotal)
+	prometheus.MustRegister(svcatInstancesTotal)
+	prometheus.MustRegister(smInstancesTotal)
+	prometheus.MustRegister(migratedBindingsTotal)
+	prometheus.MustRegister(svcatBindingsTotal)
+	prometheus.MustRegister(smBindingsTotal)
 	reconciler.WithReconcileAction(&reconcileAction{})
 }


### PR DESCRIPTION
Service Catalog migration reconciler processes high volume of data and prometheus metrics would provide great insight and instrumentation for the whole process. Example output:
```
$ curl localhost:8082/metrics | grep migra

# HELP migrated_bindings_total Migrated bindings total
# TYPE migrated_bindings_total gauge
migrated_bindings_total{instance_id="test-jw148"} 3
# HELP migrated_instances_total Migrated instances total
# TYPE migrated_instances_total gauge
migrated_instances_total{instance_id="test-jw148"} 3
```