### PR TITLE
Service catalog migration keep old instances and bindings

### DIFF
--- a/pkg/reconciler/instances/scmigration/btp_operator_migration.go
+++ b/pkg/reconciler/instances/scmigration/btp_operator_migration.go
@@ -277,24 +277,6 @@ func (m *migrator) migrateInstance(pair serviceInstancePair) error {
 		return fmt.Errorf("failed to create service instance: %v", err.Error())
 	}
 
-	if !pair.svcatInstance.DeletionTimestamp.IsZero() {
-		m.ac.Logger.Infof("svcat instance '%s' is marked for deletion, deleting it from operator", pair.svcatInstance.Name)
-		err = m.SapOperatorRestClient.Delete().Name(res.Name).Namespace(res.Namespace).Do(m.ac.Context).Error()
-		if err != nil {
-			m.ac.Logger.Errorf("failed to delete instance from operator: %v", err.Error())
-		}
-	}
-
-	pair.svcatInstance.Finalizers = []string{}
-	err = m.SvcatRestClient.Put().Name(pair.svcatInstance.Name).Namespace(pair.svcatInstance.Namespace).Resource(serviceInstances).Body(pair.svcatInstance).Do(m.ac.Context).Error()
-	if err != nil {
-		return fmt.Errorf("failed to delete finalizer from instance '%s'. Error: %v", pair.svcatInstance.Name, err.Error())
-	}
-
-	err = m.deleteSvcatResource(res.Name, res.Namespace, serviceInstances)
-	if err != nil {
-		m.ac.Logger.Infof("failed to delete svcat resource. Error: %v", err.Error())
-	}
 	m.ac.Logger.Infof("instance migrated successfully")
 	return nil
 }
@@ -365,25 +347,6 @@ func (m *migrator) migrateBinding(pair serviceBindingPair) error {
 		}
 	}
 
-	if !pair.svcatBinding.DeletionTimestamp.IsZero() {
-		m.ac.Logger.Infof("svcat binding '%s' is marked for deletion, deleting it from operator", pair.svcatBinding.Name)
-		err = m.SapOperatorRestClient.Delete().Name(res.Name).Namespace(res.Namespace).Do(m.ac.Context).Error()
-		if err != nil {
-			m.ac.Logger.Infof("failed to delete binding from operator. Error: %v", err.Error())
-		}
-	}
-
-	//remove finalizer from binding to avoid deletion of the secret
-	pair.svcatBinding.Finalizers = []string{}
-	err = m.SvcatRestClient.Put().Name(pair.svcatBinding.Name).Namespace(pair.svcatBinding.Namespace).Resource(serviceBindings).Body(pair.svcatBinding).Do(m.ac.Context).Error()
-	if err != nil {
-		return fmt.Errorf("failed to delete finalizer from binding '%s'. Error: %v", pair.svcatBinding.Name, err.Error())
-	}
-
-	err = m.deleteSvcatResource(res.Name, res.Namespace, serviceBindings)
-	if err != nil {
-		return fmt.Errorf("failed to delete svcat binding. Error: %v", err.Error())
-	}
 	m.ac.Logger.Infof("binding migrated successfully")
 	return nil
 }
@@ -488,18 +451,6 @@ func (m *migrator) ignoreAlreadyMigrated(obj, res object, err error) error {
 		return fmt.Errorf("resource already exists and is missing label %v", migratedLabel)
 	}
 	return nil
-}
-
-func (m *migrator) deleteSvcatResource(resourceName string, resourceNamespace string, resourceType string) error {
-	err := m.SapOperatorRestClient.Get().Name(resourceName).Namespace(resourceNamespace).Resource(resourceType).Do(m.ac.Context).Error()
-	if err != nil {
-		m.ac.Logger.Infof("failed to get the migrated service instance '%s' status, corresponding svcat resource will not be deleted. Error: %v", resourceName, err.Error())
-		return err
-	}
-
-	//fmt.Println(fmt.Sprintf("deleting svcat resource type '%s' named '%s' in namespace '%s'", resourceType, resourceName, resourceNamespace))
-	err = m.SvcatRestClient.Delete().Name(resourceName).Namespace(resourceNamespace).Resource(resourceType).Do(m.ac.Context).Error()
-	return err
 }
 
 func (m *migrator) getMigrateBindingRequestBody(k8sName string, secret *corev1.Secret) (string, error) {

--- a/pkg/reconciler/instances/scmigration/sc_removal.go
+++ b/pkg/reconciler/instances/scmigration/sc_removal.go
@@ -156,16 +156,6 @@ func (c *scremoval) prepareForRemoval(ac *service.ActionContext) error {
 	gvkList := []schema.GroupVersionKind{
 		{
 			Group:   "servicecatalog.k8s.io",
-			Kind:    "ServiceBindingList",
-			Version: "v1beta1",
-		},
-		{
-			Group:   "servicecatalog.k8s.io",
-			Kind:    "ServiceInstanceList",
-			Version: "v1beta1",
-		},
-		{
-			Group:   "servicecatalog.k8s.io",
 			Kind:    "ServiceBrokerList",
 			Version: "v1beta1",
 		},
@@ -268,16 +258,6 @@ func (c *scremoval) removeResources(ac *service.ActionContext) error {
 			Kind:    "UsageKind",
 			Group:   "servicecatalog.kyma-project.io",
 			Version: "v1alpha1",
-		},
-		{
-			Kind:    "ServiceBinding",
-			Group:   "servicecatalog.k8s.io",
-			Version: "v1beta1",
-		},
-		{
-			Kind:    "ServiceInstance",
-			Group:   "servicecatalog.k8s.io",
-			Version: "v1beta1",
 		},
 		{
 			Kind:    "ServiceBroker",


### PR DESCRIPTION
https://github.com/kyma-incubator/reconciler/issues/577#issuecomment-1049792731

It was discussed that we may want to keep the service catalog instances and bindings around for the first iteration of cleanup and verify the migration was successful before triggering further cleanup.