### PR TITLE
Propagate State to ReconciliationSequenceConfig to disable cleaner reconciler on normal reconciliations

### DIFF
--- a/pkg/model/clusterconfigentity.go
+++ b/pkg/model/clusterconfigentity.go
@@ -118,9 +118,9 @@ type ReconciliationSequence struct {
 }
 
 type ReconciliationSequenceConfig struct {
-	PreComponents  [][]string
-	DeleteStrategy string
-	DesiredStatus  Status
+	PreComponents        [][]string
+	DeleteStrategy       string
+	ReconciliationStatus Status
 }
 
 func newReconciliationSequence(cfg *ReconciliationSequenceConfig) *ReconciliationSequence {
@@ -132,7 +132,7 @@ func newReconciliationSequence(cfg *ReconciliationSequenceConfig) *Reconciliatio
 	})
 
 	// if a cluster is pending deletion, we need to add the cleanup component into the reconciliation
-	if cfg.DesiredStatus.IsDeletionInProgress() {
+	if cfg.ReconciliationStatus.IsDeletionInProgress() {
 		cleanupComponent.Configuration = append(cleanupComponent.Configuration, keb.Configuration{
 			Key: DeleteStrategyKey, Value: cfg.DeleteStrategy,
 		})

--- a/pkg/model/clusterconfigentity.go
+++ b/pkg/model/clusterconfigentity.go
@@ -132,7 +132,7 @@ func newReconciliationSequence(cfg *ReconciliationSequenceConfig) *Reconciliatio
 	})
 
 	// if a cluster is pending deletion, we need to add the cleanup component into the reconciliation
-	if cfg.DesiredStatus.IsDeletion() {
+	if cfg.DesiredStatus.IsDeletionInProgress() {
 		cleanupComponent.Configuration = append(cleanupComponent.Configuration, keb.Configuration{
 			Key: DeleteStrategyKey, Value: cfg.DeleteStrategy,
 		})

--- a/pkg/model/clusterconfigentity_test.go
+++ b/pkg/model/clusterconfigentity_test.go
@@ -144,14 +144,14 @@ func TestReconciliationSequence(t *testing.T) {
 		name                 string
 		preComps             [][]string
 		entity               *ClusterConfigurationEntity
-		desiredClusterStatus Status
+		reconciliationStatus Status
 		expected             *ReconciliationSequence
 		err                  error
 	}{
 		{
 			name:                 "Components and single pre-components",
 			preComps:             [][]string{{"Pre1"}, {"Pre2"}},
-			desiredClusterStatus: ClusterStatusReconciling,
+			reconciliationStatus: ClusterStatusReconciling,
 			entity: &ClusterConfigurationEntity{
 				Components: []*keb.Component{
 					{
@@ -198,7 +198,7 @@ func TestReconciliationSequence(t *testing.T) {
 		{
 			name:                 "Component and Pre-Component with ClusterStatusDeleting",
 			preComps:             [][]string{{"Pre"}},
-			desiredClusterStatus: ClusterStatusDeleting,
+			reconciliationStatus: ClusterStatusDeleting,
 			entity: &ClusterConfigurationEntity{
 				Components: []*keb.Component{
 					{
@@ -234,7 +234,7 @@ func TestReconciliationSequence(t *testing.T) {
 		{
 			name:                 "Components and multiple pre components",
 			preComps:             [][]string{{"Pre1.1", "Pre1.2"}, {"Pre2"}, {"Pre3.1", "Pre3.2"}},
-			desiredClusterStatus: ClusterStatusReconciling,
+			reconciliationStatus: ClusterStatusReconciling,
 			entity: &ClusterConfigurationEntity{
 				Components: []*keb.Component{
 					{
@@ -301,7 +301,7 @@ func TestReconciliationSequence(t *testing.T) {
 		{
 			name:                 "Components and multiple pre-components with missing pre-components",
 			preComps:             [][]string{{"Pre1.1", "Pre1.2"}, {"Pre2"}, {"Pre3.1", "Pre3.2"}},
-			desiredClusterStatus: ClusterStatusReconciling,
+			reconciliationStatus: ClusterStatusReconciling,
 			entity: &ClusterConfigurationEntity{
 				Components: []*keb.Component{
 					{
@@ -356,9 +356,9 @@ func TestReconciliationSequence(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			result := tc.entity.GetReconciliationSequence(&ReconciliationSequenceConfig{
-				PreComponents:  tc.preComps,
-				DeleteStrategy: "system",
-				DesiredStatus:  tc.desiredClusterStatus,
+				PreComponents:        tc.preComps,
+				DeleteStrategy:       "system",
+				ReconciliationStatus: tc.reconciliationStatus,
 			})
 			for idx, expected := range tc.expected.Queue {
 				require.ElementsMatch(t, result.Queue[idx], expected)

--- a/pkg/model/clusterconfigentity_test.go
+++ b/pkg/model/clusterconfigentity_test.go
@@ -196,9 +196,9 @@ func TestReconciliationSequence(t *testing.T) {
 			err: nil,
 		},
 		{
-			name:                 "Component and Pre-Component with ClusterStatusDeletePending",
+			name:                 "Component and Pre-Component with ClusterStatusDeleting",
 			preComps:             [][]string{{"Pre"}},
-			desiredClusterStatus: ClusterStatusDeletePending,
+			desiredClusterStatus: ClusterStatusDeleting,
 			entity: &ClusterConfigurationEntity{
 				Components: []*keb.Component{
 					{

--- a/pkg/model/clusterconfigentity_test.go
+++ b/pkg/model/clusterconfigentity_test.go
@@ -141,15 +141,17 @@ func TestReconciliationSequence(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		preComps [][]string
-		entity   *ClusterConfigurationEntity
-		expected *ReconciliationSequence
-		err      error
+		name                 string
+		preComps             [][]string
+		entity               *ClusterConfigurationEntity
+		desiredClusterStatus Status
+		expected             *ReconciliationSequence
+		err                  error
 	}{
 		{
-			name:     "Components and single pre-components",
-			preComps: [][]string{{"Pre1"}, {"Pre2"}},
+			name:                 "Components and single pre-components",
+			preComps:             [][]string{{"Pre1"}, {"Pre2"}},
+			desiredClusterStatus: ClusterStatusReconciling,
 			entity: &ClusterConfigurationEntity{
 				Components: []*keb.Component{
 					{
@@ -170,9 +172,6 @@ func TestReconciliationSequence(t *testing.T) {
 				Queue: [][]*keb.Component{
 					{
 						crdComponent,
-					},
-					{
-						cleanupComponent,
 					},
 					{
 						{
@@ -197,8 +196,45 @@ func TestReconciliationSequence(t *testing.T) {
 			err: nil,
 		},
 		{
-			name:     "Components and multiple pre components",
-			preComps: [][]string{{"Pre1.1", "Pre1.2"}, {"Pre2"}, {"Pre3.1", "Pre3.2"}},
+			name:                 "Component and Pre-Component with ClusterStatusDeletePending",
+			preComps:             [][]string{{"Pre"}},
+			desiredClusterStatus: ClusterStatusDeletePending,
+			entity: &ClusterConfigurationEntity{
+				Components: []*keb.Component{
+					{
+						Component: "Pre",
+					},
+					{
+						Component: "Comp",
+					},
+				},
+			},
+			expected: &ReconciliationSequence{
+				Queue: [][]*keb.Component{
+					{
+						crdComponent,
+					},
+					{
+						cleanupComponent,
+					},
+					{
+						{
+							Component: "Pre",
+						},
+					},
+					{
+						{
+							Component: "Comp",
+						},
+					},
+				},
+			},
+			err: nil,
+		},
+		{
+			name:                 "Components and multiple pre components",
+			preComps:             [][]string{{"Pre1.1", "Pre1.2"}, {"Pre2"}, {"Pre3.1", "Pre3.2"}},
+			desiredClusterStatus: ClusterStatusReconciling,
 			entity: &ClusterConfigurationEntity{
 				Components: []*keb.Component{
 					{
@@ -228,9 +264,6 @@ func TestReconciliationSequence(t *testing.T) {
 				Queue: [][]*keb.Component{
 					{
 						crdComponent,
-					},
-					{
-						cleanupComponent,
 					},
 					{
 						{
@@ -266,8 +299,9 @@ func TestReconciliationSequence(t *testing.T) {
 			err: nil,
 		},
 		{
-			name:     "Components and multiple pre-components with missing pre-components",
-			preComps: [][]string{{"Pre1.1", "Pre1.2"}, {"Pre2"}, {"Pre3.1", "Pre3.2"}},
+			name:                 "Components and multiple pre-components with missing pre-components",
+			preComps:             [][]string{{"Pre1.1", "Pre1.2"}, {"Pre2"}, {"Pre3.1", "Pre3.2"}},
+			desiredClusterStatus: ClusterStatusReconciling,
 			entity: &ClusterConfigurationEntity{
 				Components: []*keb.Component{
 					{
@@ -291,9 +325,6 @@ func TestReconciliationSequence(t *testing.T) {
 				Queue: [][]*keb.Component{
 					{
 						crdComponent,
-					},
-					{
-						cleanupComponent,
 					},
 					{
 						{
@@ -324,7 +355,11 @@ func TestReconciliationSequence(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := tc.entity.GetReconciliationSequence(&ReconciliationSequenceConfig{PreComponents: tc.preComps, DeleteStrategy: "system"})
+			result := tc.entity.GetReconciliationSequence(&ReconciliationSequenceConfig{
+				PreComponents:  tc.preComps,
+				DeleteStrategy: "system",
+				DesiredStatus:  tc.desiredClusterStatus,
+			})
 			for idx, expected := range tc.expected.Queue {
 				require.ElementsMatch(t, result.Queue[idx], expected)
 			}

--- a/pkg/model/clusterstatus.go
+++ b/pkg/model/clusterstatus.go
@@ -20,8 +20,8 @@ const (
 	ClusterStatusReady                   Status = "ready"
 )
 
-func (s Status) IsDeletion() bool {
-	return s == ClusterStatusDeletePending || s == ClusterStatusDeleting
+func (s Status) IsDeletionInProgress() bool {
+	return s == ClusterStatusDeleting
 }
 
 func (s Status) IsDeleteCandidate() bool {

--- a/pkg/scheduler/invoker/localinvoker_test.go
+++ b/pkg/scheduler/invoker/localinvoker_test.go
@@ -65,7 +65,7 @@ func runLocalReconciler(t *testing.T, simulateError bool) (reconciliation.Reposi
 		SchedulingID: reconEntity.SchedulingID,
 	})
 	require.NoError(t, err)
-	if clusterStateMock.Status.Status.IsDeletion() {
+	if clusterStateMock.Status.Status.IsDeletionInProgress() {
 		require.Len(t, opEntities, 7, "reconciliation sequence has 7 ops (5 + crds + cleaner)")
 	} else {
 		require.Len(t, opEntities, 6, "reconciliation sequence has 6 ops (5 + crds)")

--- a/pkg/scheduler/invoker/localinvoker_test.go
+++ b/pkg/scheduler/invoker/localinvoker_test.go
@@ -65,7 +65,11 @@ func runLocalReconciler(t *testing.T, simulateError bool) (reconciliation.Reposi
 		SchedulingID: reconEntity.SchedulingID,
 	})
 	require.NoError(t, err)
-	require.Len(t, opEntities, 7)
+	if clusterStateMock.Status.Status.IsDeletion() {
+		require.Len(t, opEntities, 7, "reconciliation sequence has 7 ops (5 + crds + cleaner)")
+	} else {
+		require.Len(t, opEntities, 6, "reconciliation sequence has 6 ops (5 + crds)")
+	}
 	opEntity := opEntities[0]
 
 	//create callback fct for receiving reconciler feedbacks

--- a/pkg/scheduler/invoker/remoteinvoker_test.go
+++ b/pkg/scheduler/invoker/remoteinvoker_test.go
@@ -33,7 +33,11 @@ func TestRemoteInvoker(t *testing.T) {
 		SchedulingID: reconEntity.SchedulingID,
 	})
 	require.NoError(t, err)
-	require.Len(t, opEntities, 7)
+	if clusterStateMock.Status.Status.IsDeletion() {
+		require.Len(t, opEntities, 7, "reconciliation sequence has 7 ops (5 + crds + cleaner)")
+	} else {
+		require.Len(t, opEntities, 6, "reconciliation sequence has 6 ops (5 + crds)")
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	startServer(ctx, t)

--- a/pkg/scheduler/invoker/remoteinvoker_test.go
+++ b/pkg/scheduler/invoker/remoteinvoker_test.go
@@ -33,7 +33,7 @@ func TestRemoteInvoker(t *testing.T) {
 		SchedulingID: reconEntity.SchedulingID,
 	})
 	require.NoError(t, err)
-	if clusterStateMock.Status.Status.IsDeletion() {
+	if clusterStateMock.Status.Status.IsDeletionInProgress() {
 		require.Len(t, opEntities, 7, "reconciliation sequence has 7 ops (5 + crds + cleaner)")
 	} else {
 		require.Len(t, opEntities, 6, "reconciliation sequence has 6 ops (5 + crds)")

--- a/pkg/scheduler/invoker/test.go
+++ b/pkg/scheduler/invoker/test.go
@@ -48,7 +48,7 @@ var clusterStateMock = &cluster.State{
 		RuntimeID:      "testCluster",
 		ClusterVersion: 1,
 		ConfigVersion:  1,
-		Status:         model.ClusterStatusReconcilePending,
+		Status:         model.ClusterStatusReconciling,
 	},
 }
 

--- a/pkg/scheduler/reconciliation/inmemory.go
+++ b/pkg/scheduler/reconciliation/inmemory.go
@@ -61,7 +61,7 @@ func (r *InMemoryReconciliationRepository) CreateReconciliation(state *cluster.S
 	}
 
 	opType := model.OperationTypeReconcile
-	if state.Status.Status.IsDeletion() {
+	if state.Status.Status.IsDeletionInProgress() {
 		opType = model.OperationTypeDelete
 	}
 

--- a/pkg/scheduler/reconciliation/persistent.go
+++ b/pkg/scheduler/reconciliation/persistent.go
@@ -84,7 +84,7 @@ func (r *PersistentReconciliationRepository) CreateReconciliation(state *cluster
 			state.Cluster.RuntimeID, reconEntity.SchedulingID)
 
 		opType := model.OperationTypeReconcile
-		if state.Status.Status.IsDeletion() {
+		if state.Status.Status.IsDeletionInProgress() {
 			opType = model.OperationTypeDelete
 		}
 

--- a/pkg/scheduler/reconciliation/reconciliation_test.go
+++ b/pkg/scheduler/reconciliation/reconciliation_test.go
@@ -374,19 +374,17 @@ func TestReconciliationRepository(t *testing.T) {
 					SchedulingID: reconEntity.SchedulingID,
 				})
 				require.NoError(t, err)
-				require.Len(t, opsEntities, 5)
+				require.Len(t, opsEntities, 4)
 
 				//verify priorities
 				for _, opEntity := range opsEntities {
 					switch opEntity.Component {
 					case "CRDs":
 						require.Equal(t, int64(1), opEntity.Priority)
-					case "cleaner":
-						require.Equal(t, int64(2), opEntity.Priority)
 					case "comp3":
-						require.Equal(t, int64(3), opEntity.Priority)
+						require.Equal(t, int64(2), opEntity.Priority)
 					default:
-						require.Equal(t, int64(4), opEntity.Priority)
+						require.Equal(t, int64(3), opEntity.Priority)
 					}
 				}
 
@@ -415,14 +413,14 @@ func TestReconciliationRepository(t *testing.T) {
 					SchedulingID: reconEntity.SchedulingID,
 				})
 				require.NoError(t, err)
-				require.Len(t, opsEntitiesAll, 5)
+				require.Len(t, opsEntitiesAll, 4)
 
 				opsEntitiesNew, err := reconRepo.GetOperations(&operation.FilterMixer{Filters: []operation.Filter{
 					&operation.WithSchedulingID{SchedulingID: reconEntity.SchedulingID},
 					&operation.WithStates{States: []model.OperationState{model.OperationStateNew}},
 				}})
 				require.NoError(t, err)
-				require.Len(t, opsEntitiesNew, 5)
+				require.Len(t, opsEntitiesNew, 4)
 
 				err = reconRepo.UpdateOperationState(opsEntitiesAll[0].SchedulingID, opsEntitiesAll[0].CorrelationID, model.OperationStateError, false, "err")
 				require.NoError(t, err)
@@ -450,24 +448,19 @@ func TestReconciliationRepository(t *testing.T) {
 				require.NoError(t, err)
 				err = reconRepo.UpdateOperationState(opsEntitiesAll[3].SchedulingID, opsEntitiesAll[3].CorrelationID, model.OperationStateDone, false)
 				require.NoError(t, err)
-				err = reconRepo.UpdateOperationState(opsEntitiesAll[4].SchedulingID, opsEntitiesAll[4].CorrelationID,
-					model.OperationStateDone, false)
-				require.NoError(t, err)
 				opsEntitiesDone, err := reconRepo.GetOperations(&operation.FilterMixer{Filters: []operation.Filter{
 					&operation.WithSchedulingID{SchedulingID: reconEntity.SchedulingID},
 					&operation.WithStates{States: []model.OperationState{model.OperationStateDone}},
 				}})
 
 				require.NoError(t, err)
-				require.Len(t, opsEntitiesDone, 3)
+				require.Len(t, opsEntitiesDone, 2)
 				require.ElementsMatch(t, []string{
 					opsEntitiesAll[2].CorrelationID,
 					opsEntitiesAll[3].CorrelationID,
-					opsEntitiesAll[4].CorrelationID,
 				}, []string{
 					opsEntitiesDone[0].CorrelationID,
 					opsEntitiesDone[1].CorrelationID,
-					opsEntitiesDone[2].CorrelationID,
 				})
 
 				//no operation should be in state NEW anymore
@@ -492,7 +485,7 @@ func TestReconciliationRepository(t *testing.T) {
 				})
 
 				require.NoError(t, err)
-				require.Len(t, opsEntities, 5)
+				require.Len(t, opsEntities, 4)
 
 				//only the operation with prio 1 has to be returned
 				opsEntitiesPrio1, err := reconRepo.GetProcessableOperations(0)
@@ -535,12 +528,12 @@ func TestReconciliationRepository(t *testing.T) {
 					SchedulingID: reconEntity1.SchedulingID,
 				})
 				require.NoError(t, err)
-				require.Len(t, opsEntities1, 5)
+				require.Len(t, opsEntities1, 4)
 				opsEntities2, err := reconRepo.GetOperations(&operation.WithSchedulingID{
 					SchedulingID: reconEntity2.SchedulingID,
 				})
 				require.NoError(t, err)
-				require.Len(t, opsEntities2, 3)
+				require.Len(t, opsEntities2, 2)
 
 				//only the operation with prio 1 has to be returned
 				opsEntitiesPrio1, err := reconRepo.GetProcessableOperations(0)
@@ -587,7 +580,7 @@ func TestReconciliationRepository(t *testing.T) {
 				//get existing operations
 				opsRecon, err := reconRepo.GetReconcilingOperations()
 				require.NoError(t, err)
-				require.Len(t, opsRecon, 8)
+				require.Len(t, opsRecon, 6)
 			},
 		},
 		{
@@ -600,7 +593,7 @@ func TestReconciliationRepository(t *testing.T) {
 					SchedulingID: reconEntity.SchedulingID,
 				})
 				require.NoError(t, err)
-				require.Len(t, opsEntities, 5)
+				require.Len(t, opsEntities, 4)
 
 				sID := opsEntities[0].SchedulingID
 				cID := opsEntities[0].CorrelationID

--- a/pkg/scheduler/service/bookkeepingtask_test.go
+++ b/pkg/scheduler/service/bookkeepingtask_test.go
@@ -129,10 +129,10 @@ func newReconciliation(t *testing.T, reconRepo reconciliation.Repository, cluste
 func TestBookkeepingTaskParallel(t *testing.T) {
 
 	threadCount := 25
-	//errorCount should be equal to 72, since there are three operations scheduled,
+	//errorCount should be equal to 48, since there are 2 operations scheduled,
 	//and 25 threads try to mark them as orphans at the same time
-	//three should succeed, resolving in 72 errors
-	orphanErrors := 72
+	//three should succeed, resolving in (2*25)-2=48 errors
+	orphanErrors := 48
 	//finishErrors should be equal to 24, since 25 threads try to update the cluster state to be finished
 	//only one should succeed resolving in 24 errors
 	finishErrors := 24

--- a/pkg/scheduler/service/run_test.go
+++ b/pkg/scheduler/service/run_test.go
@@ -165,7 +165,7 @@ func runRemote(t *testing.T, expectedClusterStatus model.Status, timeout time.Du
 	require.Len(t, recons, 1)
 
 	schedulingID := recons[0].SchedulingID
-	require.Equal(t, 3, countOperations(t, reconRepo, schedulingID))
+	require.Equal(t, 2, countOperations(t, reconRepo, schedulingID))
 
 	time.Sleep(15 * time.Second) //give the cleaner some time to remove old entities
 

--- a/pkg/scheduler/service/scheduler.go
+++ b/pkg/scheduler/service/scheduler.go
@@ -110,6 +110,7 @@ func (s *scheduler) Run(ctx context.Context, transition *ClusterStatusTransition
 			if err := transition.StartReconciliation(clusterState.Cluster.RuntimeID, clusterState.Configuration.Version, &model.ReconciliationSequenceConfig{
 				PreComponents:  config.PreComponents,
 				DeleteStrategy: string(config.DeleteStrategy),
+				DesiredStatus:  clusterState.Status.Status,
 			}); err == nil {
 				s.logger.Infof("Scheduler triggered reconciliation for cluster '%s' "+
 					"(clusterVersion:%d/configVersion:%d/status:%s/last status update:%.2f min)", clusterState.Cluster.RuntimeID,

--- a/pkg/scheduler/service/scheduler.go
+++ b/pkg/scheduler/service/scheduler.go
@@ -108,9 +108,9 @@ func (s *scheduler) Run(ctx context.Context, transition *ClusterStatusTransition
 		select {
 		case clusterState := <-queue:
 			if err := transition.StartReconciliation(clusterState.Cluster.RuntimeID, clusterState.Configuration.Version, &model.ReconciliationSequenceConfig{
-				PreComponents:  config.PreComponents,
-				DeleteStrategy: string(config.DeleteStrategy),
-				DesiredStatus:  clusterState.Status.Status,
+				PreComponents:        config.PreComponents,
+				DeleteStrategy:       string(config.DeleteStrategy),
+				ReconciliationStatus: clusterState.Status.Status,
 			}); err == nil {
 				s.logger.Infof("Scheduler triggered reconciliation for cluster '%s' "+
 					"(clusterVersion:%d/configVersion:%d/status:%s/last status update:%.2f min)", clusterState.Cluster.RuntimeID,

--- a/pkg/scheduler/service/scheduler_test.go
+++ b/pkg/scheduler/service/scheduler_test.go
@@ -86,7 +86,11 @@ func requiredReconciliationEntity(t *testing.T, reconRepo reconciliation.Reposit
 		SchedulingID: recons[0].SchedulingID,
 	})
 	require.NoError(t, err)
-	require.Len(t, ops, 3)
+	if state.Status.Status.IsDeletion() {
+		require.Len(t, ops, 3) // cleaner is expected if reconciliation is a deletion
+	} else {
+		require.Len(t, ops, 2)
+	}
 	require.Equal(t, ops[0].RuntimeID, state.Cluster.RuntimeID)
 }
 

--- a/pkg/scheduler/service/scheduler_test.go
+++ b/pkg/scheduler/service/scheduler_test.go
@@ -86,7 +86,7 @@ func requiredReconciliationEntity(t *testing.T, reconRepo reconciliation.Reposit
 		SchedulingID: recons[0].SchedulingID,
 	})
 	require.NoError(t, err)
-	if state.Status.Status.IsDeletion() {
+	if state.Status.Status.IsDeletionInProgress() {
 		require.Len(t, ops, 3) // cleaner is expected if reconciliation is a deletion
 	} else {
 		require.Len(t, ops, 2)


### PR DESCRIPTION
fixes #715

Allows distinguishing between delete reconciliations and normal reconciliations, making sure the cleaner reconciler is only scheduled in case of delete.

Adds test case in unit test and adopts scheduler test to be status-aware.

![Sample of Cluster Deploy without cleaner reconciler](https://user-images.githubusercontent.com/64904610/155988621-f9de8a66-4607-4483-b581-3f39dbb3fd3b.png)


Edit:
Due to a change of ClusterState, this requires an upstream change in the way CLI is handing over cluster state:
https://github.com/kyma-project/cli/blob/3f016792a4f359a395c1db68aa5704af452c98fb/internal/deploy/deploy.go#L129-L131

this will need to be changed to 
```go
status := model.ClusterStatusReconciling
if delete {
	status = model.ClusterStatusDeleting
}
```