### PR TITLE
Use environment variable to obtain the auth token

### DIFF
--- a/pkg/reconciler/git/clone.go
+++ b/pkg/reconciler/git/clone.go
@@ -14,7 +14,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const gitCloneTokenEnv = "GIT_CLONE_TOKEN"
+const gitCloneTokenEnv = "GIT_CLONE_TOKEN" //#nosec [-- Ignore nosec false positive. It's not a credential, just an environment variable name]
 
 type Cloner struct {
 	repo         *reconciler.Repository

--- a/pkg/reconciler/git/clone_test.go
+++ b/pkg/reconciler/git/clone_test.go
@@ -6,20 +6,15 @@ import (
 	"path"
 	"testing"
 
-	"github.com/kyma-incubator/reconciler/pkg/logger"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
-
-	"github.com/go-git/go-git/v5/plumbing/transport"
-	"github.com/go-git/go-git/v5/plumbing/transport/http"
-	"github.com/kyma-incubator/reconciler/pkg/reconciler"
-	"github.com/kyma-incubator/reconciler/pkg/reconciler/git/mocks"
-	"github.com/stretchr/testify/assert"
-
 	"github.com/alcortesm/tgz"
 	"github.com/go-git/go-git/v5"
 	gitp "github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/kyma-incubator/reconciler/pkg/logger"
+	"github.com/kyma-incubator/reconciler/pkg/reconciler"
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/git/mocks"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -67,7 +62,7 @@ func TestCloneRepo(t *testing.T) {
 	clonerMock.On("ResolveRevision",
 		gitp.Revision("1.0.0")).
 		Return(repo.ResolveRevision("1.0.0"))
-	cloner, _ := NewCloner(clonerMock, &r, true, fake.NewSimpleClientset(), logger.NewLogger(true))
+	cloner, _ := NewCloner(clonerMock, &r, true, logger.NewLogger(true))
 
 	headRef, err := repo.Head()
 	require.NoError(t, err)
@@ -87,7 +82,7 @@ func TestCloneRepo(t *testing.T) {
 	require.Equal(t, "Add README\n", commit.Message)
 
 	t.Run("Should add auth data if token namespace set and token exists", func(t *testing.T) {
-		token := "tokeValue"
+		t.Setenv(gitCloneTokenEnv, "tokenValue")
 
 		clonerMock.On("Clone", context.Background(), "/test", false, &git.CloneOptions{
 			Depth:      0,
@@ -95,15 +90,14 @@ func TestCloneRepo(t *testing.T) {
 			NoCheckout: true,
 			Auth: &http.BasicAuth{
 				Username: "xxx", // anything but an empty string
-				Password: token,
+				Password: "tokenValue",
 			},
 			RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
 		}).Return(repo, nil)
 
 		cloner, _ := NewCloner(clonerMock, &reconciler.Repository{
-			URL:            repoURL,
-			TokenNamespace: "default",
-		}, false, clientWithToken("github.com", "default", "token", token), logger.NewLogger(true))
+			URL: repoURL,
+		}, false, logger.NewLogger(true))
 
 		_, err := cloner.Clone("/test")
 		assert.NoError(t, err)
@@ -114,7 +108,7 @@ func TestTokenRead(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Should read correct token", func(t *testing.T) {
-		t.Setenv("GIT_CLONE_TOKEN", "tokenValue")
+		t.Setenv(gitCloneTokenEnv, "tokenValue")
 
 		cloner := Cloner{}
 
@@ -128,8 +122,7 @@ func TestTokenRead(t *testing.T) {
 
 	t.Run("Should return nil when token not found", func(t *testing.T) {
 		repo := reconciler.Repository{
-			URL:            "https://localhost",
-			TokenNamespace: "default",
+			URL: "https://localhost",
 		}
 		cloner := Cloner{
 			repo:   &repo,
@@ -140,38 +133,4 @@ func TestTokenRead(t *testing.T) {
 
 		assert.Nil(t, auth)
 	})
-
-	t.Run("Should parse URL", func(t *testing.T) {
-		assertParsed(t, "localhost", "localhost/path")
-		assertParsed(t, "localhost", "localhost")
-		assertParsed(t, "localhost", "localhost:8080")
-		assertParsed(t, "localhost", "http://localhost:8080")
-		assertParsed(t, "localhost", "www.localhost:8080")
-		assertParsed(t, "localhost", "https://www.localhost:8080")
-		assertParsed(t, "192.168.1.2", "192.168.1.2")
-		assertParsed(t, "192.168.1.2", "192.168.1.2:8080")
-	})
-}
-
-func clientWithToken(name, namespace, key, value string) *fake.Clientset {
-	client := fake.NewSimpleClientset(&v1.Secret{
-		TypeMeta: metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Immutable: nil,
-		Data: map[string][]byte{
-			key: []byte(value),
-		},
-		StringData: nil,
-		Type:       "",
-	})
-	return client
-}
-
-func assertParsed(t *testing.T, expected string, url string) {
-	key, err := mapSecretKey(url)
-	assert.NoError(t, err)
-	assert.Equal(t, expected, key)
 }

--- a/pkg/reconciler/git/clone_test.go
+++ b/pkg/reconciler/git/clone_test.go
@@ -113,88 +113,32 @@ func TestCloneRepo(t *testing.T) {
 func TestTokenRead(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Should read correct token secret", func(t *testing.T) {
-		client := clientWithToken("localhost", "default", "token", "tokenValue")
+	t.Run("Should read correct token", func(t *testing.T) {
+		t.Setenv("GIT_CLONE_TOKEN", "tokenValue")
 
-		repo := reconciler.Repository{
-			URL:            "https://localhost",
-			TokenNamespace: "default",
-		}
+		cloner := Cloner{}
 
-		cloner := Cloner{
-			repo:               &repo,
-			autoCheckout:       false,
-			repoClient:         nil,
-			inClusterClientSet: client,
-			logger:             logger.NewLogger(true),
-		}
+		auth := cloner.buildAuth()
 
-		auth, err := cloner.buildAuth()
-
-		assert.NoError(t, err)
 		assert.Equal(t, &http.BasicAuth{
 			Username: "xxx",
 			Password: "tokenValue",
 		}, auth)
 	})
 
-	t.Run("Should ignore error when token secret not found", func(t *testing.T) {
-		client := fake.NewSimpleClientset()
-
+	t.Run("Should return nil when token not found", func(t *testing.T) {
 		repo := reconciler.Repository{
 			URL:            "https://localhost",
 			TokenNamespace: "default",
 		}
-
 		cloner := Cloner{
-			repo:               &repo,
-			autoCheckout:       false,
-			repoClient:         nil,
-			inClusterClientSet: client,
-			logger:             logger.NewLogger(true),
+			repo:   &repo,
+			logger: logger.NewLogger(true),
 		}
 
-		_, err := cloner.buildAuth()
+		auth := cloner.buildAuth()
 
-		assert.NoError(t, err)
-	})
-
-	t.Run("Should ignore error when clientset not set", func(t *testing.T) {
-		repo := reconciler.Repository{
-			URL:            "https://localhost",
-			TokenNamespace: "default",
-		}
-
-		cloner := Cloner{
-			repo:               &repo,
-			autoCheckout:       false,
-			repoClient:         nil,
-			inClusterClientSet: nil,
-			logger:             logger.NewLogger(true),
-		}
-
-		_, err := cloner.buildAuth()
-
-		assert.NoError(t, err)
-	})
-
-	t.Run("Should ignore error when TokenNamespace not set", func(t *testing.T) {
-		repo := reconciler.Repository{
-			URL:            "https://localhost",
-			TokenNamespace: "",
-		}
-
-		cloner := Cloner{
-			repo:               &repo,
-			autoCheckout:       false,
-			repoClient:         nil,
-			inClusterClientSet: nil,
-			logger:             logger.NewLogger(true),
-		}
-
-		_, err := cloner.buildAuth()
-
-		assert.NoError(t, err)
+		assert.Nil(t, auth)
 	})
 
 	t.Run("Should parse URL", func(t *testing.T) {

--- a/pkg/reconciler/model.go
+++ b/pkg/reconciler/model.go
@@ -95,8 +95,7 @@ func (r *Task) Validate() error {
 }
 
 type Repository struct {
-	URL            string `json:"url"`
-	TokenNamespace string `json:"tokenNamespace"`
+	URL string `json:"url"`
 }
 
 func (r *Repository) String() string {

--- a/pkg/scheduler/invoker/invoker.go
+++ b/pkg/scheduler/invoker/invoker.go
@@ -46,12 +46,6 @@ func (p *Params) newTask() *reconciler.Task {
 		version = p.ComponentToReconcile.Version
 	}
 
-	configuration := p.ComponentToReconcile.ConfigurationAsMap()
-	tokenNamespace := configuration["repo.token.namespace"]
-	if tokenNamespace == nil {
-		tokenNamespace = ""
-	}
-
 	return &reconciler.Task{
 		ComponentsReady: p.ComponentsReady,
 		Component:       p.ComponentToReconcile.Component,
@@ -59,12 +53,12 @@ func (p *Params) newTask() *reconciler.Task {
 		Version:         version,
 		URL:             url,
 		Profile:         p.ClusterState.Configuration.KymaProfile,
-		Configuration:   configuration,
+		Configuration:   p.ComponentToReconcile.ConfigurationAsMap(),
 		Kubeconfig:      p.ClusterState.Cluster.Kubeconfig,
 		Metadata:        *p.ClusterState.Cluster.Metadata,
 		CorrelationID:   p.CorrelationID,
 		Repository: &reconciler.Repository{
-			URL:            url,
+			URL: url,
 		},
 		Type: p.Type,
 		ComponentConfiguration: reconciler.ComponentConfiguration{

--- a/pkg/scheduler/invoker/invoker.go
+++ b/pkg/scheduler/invoker/invoker.go
@@ -2,7 +2,6 @@ package invoker
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/kyma-incubator/reconciler/pkg/cluster"
@@ -66,7 +65,6 @@ func (p *Params) newTask() *reconciler.Task {
 		CorrelationID:   p.CorrelationID,
 		Repository: &reconciler.Repository{
 			URL:            url,
-			TokenNamespace: fmt.Sprint(tokenNamespace),
 		},
 		Type: p.Type,
 		ComponentConfiguration: reconciler.ComponentConfiguration{

--- a/pkg/scheduler/invoker/invoker_test.go
+++ b/pkg/scheduler/invoker/invoker_test.go
@@ -33,6 +33,5 @@ func TestInvoker(t *testing.T) {
 	}
 
 	task := params.newTask()
-	assert.Equal(t, "", task.Repository.TokenNamespace, "Should parse repo token namespace correctly")
 	assert.Equal(t, model.OperationTypeDelete, task.Type, "Task type should equal operation type")
 }


### PR DESCRIPTION
Description:
- use the `GIT_CLONE_TOKEN` environment variable in the Component Reconciler to obtain the token needed to clone the git repository with the chart
- remove the k8s Secret lookup as it's not needed anymore

See the related issue - https://github.com/kyma-incubator/reconciler/issues/418