### PR TITLE
Add hydra-maester startup shift

### DIFF
--- a/pkg/reconciler/instances/ory/hydra/syncer.go
+++ b/pkg/reconciler/instances/ory/hydra/syncer.go
@@ -35,6 +35,7 @@ const (
 	hydraPodName           = "app.kubernetes.io/name=hydra"
 	hydraMaesterPodName    = "app.kubernetes.io/name=hydra-maester"
 	hydraMaesterDeployment = "ory-hydra-maester"
+	startupShift           = -2 * time.Second
 )
 
 func (c *DefaultHydraSyncer) TriggerSynchronization(context context.Context, client internalKubernetes.Client, logger *zap.SugaredLogger, namespace string, forceSync bool) error {
@@ -74,8 +75,7 @@ func restartHydraMaesterDeploymentNeeded(context context.Context, client kuberne
 		return false, err
 	}
 	logger.Debugf("Earliest hydra-maester restart time: %s ", earliestHydraMaesterPodStartTime.String())
-
-	return earliestHydraPodStartTime.After(earliestHydraMaesterPodStartTime), nil
+	return earliestHydraPodStartTime.After(earliestHydraMaesterPodStartTime.Add(startupShift)), nil
 }
 
 func getEarliestPodStartTime(context context.Context, label string, client kubernetes.Interface, logger *zap.SugaredLogger, namespace string) (time.Time, error) {

--- a/pkg/reconciler/instances/ory/hydra/syncer_test.go
+++ b/pkg/reconciler/instances/ory/hydra/syncer_test.go
@@ -33,7 +33,7 @@ func Test_TriggerSynchronization(t *testing.T) {
 		addPod(kubeclient, "hydra1", "hydra", hydraStartTimePod1, t, v1.PodRunning)
 		addPod(kubeclient, "hydra2", "hydra", hydraStartTimePod2, t, v1.PodRunning)
 		addPod(kubeclient, "hydra3", "hydra", hydraStartTimePod3, t, v1.PodFailed)
-		createDeployment(kubeclient, "ory-hydra-maester", hydraMasesterPodStartTime, t)
+		createDeployment(kubeclient, hydraMasesterPodStartTime, t)
 		addPod(kubeclient, "hydra-maester1", "hydra-maester", hydraMasesterPodStartTime, t, v1.PodRunning)
 
 		// when
@@ -54,7 +54,7 @@ func Test_TriggerSynchronization(t *testing.T) {
 		addPod(kubeclient, "hydra1", "hydra", hydraStartTimePod1, t, v1.PodRunning)
 		addPod(kubeclient, "hydra2", "hydra", hydraStartTimePod2, t, v1.PodRunning)
 		addPod(kubeclient, "hydra3", "hydra", hydraStartTimePod3, t, v1.PodPending)
-		createDeployment(kubeclient, "ory-hydra-maester", hydraMasesterPodStartTime, t)
+		createDeployment(kubeclient, hydraMasesterPodStartTime, t)
 		addPod(kubeclient, "hydra-maester", "hydra-maester", hydraMasesterPodStartTime, t, v1.PodRunning)
 
 		// when
@@ -75,7 +75,7 @@ func Test_TriggerSynchronization(t *testing.T) {
 		addPod(kubeclient, "hydra1", "hydra", hydraStartTimePod1, t, v1.PodRunning)
 		addPod(kubeclient, "hydra2", "hydra", hydraStartTimePod2, t, v1.PodRunning)
 		addPod(kubeclient, "hydra3", "hydra", hydraStartTimePod3, t, v1.PodPending)
-		createDeployment(kubeclient, "ory-hydra-maester", hydraMasesterPodStartTime, t)
+		createDeployment(kubeclient, hydraMasesterPodStartTime, t)
 		addPod(kubeclient, "hydra-maester", "hydra-maester", hydraMasesterPodStartTime, t, v1.PodRunning)
 
 		// when
@@ -91,13 +91,13 @@ func Test_TriggerSynchronization(t *testing.T) {
 		// given
 		hydraStartTimePod1 := time.Date(2021, 10, 10, 10, 10, 10, 10, time.UTC)
 		hydraStartTimePod2 := time.Date(2021, 10, 10, 10, 10, 7, 10, time.UTC)
-		hydraMasesterPodStartTime := time.Date(2021, 10, 10, 10, 10, 7, 100, time.UTC)
+		hydraMaesterPodStartTime := time.Date(2021, 10, 10, 10, 10, 7, 100, time.UTC)
 
 		kubeclient := fakeClient()
 		addPod(kubeclient, "hydra1", "hydra", hydraStartTimePod1, t, v1.PodRunning)
 		addPod(kubeclient, "hydra2", "hydra", hydraStartTimePod2, t, v1.PodRunning)
-		createDeployment(kubeclient, "ory-hydra-maester", hydraMasesterPodStartTime, t)
-		addPod(kubeclient, "hydra-maester1", "hydra-maester", hydraMasesterPodStartTime, t, v1.PodRunning)
+		createDeployment(kubeclient, hydraMaesterPodStartTime, t)
+		addPod(kubeclient, "hydra-maester1", "hydra-maester", hydraMaesterPodStartTime, t, v1.PodRunning)
 
 		// when
 		err := NewDefaultHydraSyncer(handler.NewDefaultRolloutHandler()).TriggerSynchronization(context.TODO(), kubeclient, logger, testNamespace, false)
@@ -202,7 +202,7 @@ func addPod(client *k8smocks.Client, podName string, podLabel string, startTime 
 	require.NoError(t, err)
 }
 
-func createDeployment(client *k8smocks.Client, deploymentName string, startTime time.Time, t *testing.T) {
+func createDeployment(client *k8smocks.Client, startTime time.Time, t *testing.T) {
 	fakeClient, _ := client.Clientset()
 	deplMock := fakeClient.AppsV1().Deployments(testNamespace)
 
@@ -214,7 +214,7 @@ func createDeployment(client *k8smocks.Client, deploymentName string, startTime 
 	replicas := int32(1)
 	deploymentSpec := &appv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:              deploymentName,
+			Name:              "ory-hydra-maester",
 			Namespace:         testNamespace,
 			CreationTimestamp: metav1.NewTime(startTime),
 		},
@@ -228,7 +228,7 @@ func createDeployment(client *k8smocks.Client, deploymentName string, startTime 
 	}
 	replicaSets := &appv1.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:              deploymentName + "-1",
+			Name:              "ory-hydra-maester" + "-1",
 			Namespace:         testNamespace,
 			CreationTimestamp: metav1.NewTime(startTime),
 			OwnerReferences:   []metav1.OwnerReference{*metav1.NewControllerRef(deploymentSpec, deploymentSpec.GroupVersionKind())},

--- a/pkg/reconciler/instances/ory/test/ory_integration_test.go
+++ b/pkg/reconciler/instances/ory/test/ory_integration_test.go
@@ -112,6 +112,7 @@ func TestOryIntegrationEvaluation(t *testing.T) {
 	t.Run("ensure that ory-oathkeeper pod is deployed", func(t *testing.T) {
 		options := metav1.ListOptions{
 			LabelSelector: "app.kubernetes.io/name=oathkeeper",
+			FieldSelector: "status.phase=Running",
 		}
 		podsList, err := setup.getPods(options)
 		require.NoError(t, err)
@@ -122,6 +123,7 @@ func TestOryIntegrationEvaluation(t *testing.T) {
 	t.Run("ensure that ory-hydra pod is deployed", func(t *testing.T) {
 		options := metav1.ListOptions{
 			LabelSelector: "app.kubernetes.io/name=hydra",
+			FieldSelector: "status.phase=Running",
 		}
 		podsList, err := setup.getPods(options)
 		require.NoError(t, err)
@@ -132,6 +134,7 @@ func TestOryIntegrationEvaluation(t *testing.T) {
 	t.Run("ensure that ory-hydra-maester pod is deployed", func(t *testing.T) {
 		options := metav1.ListOptions{
 			LabelSelector: "app.kubernetes.io/name=hydra-maester",
+			FieldSelector: "status.phase=Running",
 		}
 		podsList, err := setup.getPods(options)
 		require.NoError(t, err)


### PR DESCRIPTION
Add a startup shift for check if hydra sync needs to be called, which should enforce hdyra-maester to synchronize OAuth2Clients to hydra and prevent failing pipelines :https://github.com/kyma-project/kyma/issues/13498