### PR TITLE
Replace istioctl upgrade usage from Istio reconciler with apply

### DIFF
--- a/pkg/reconciler/instances/istio/istioctl/commander.go
+++ b/pkg/reconciler/instances/istio/istioctl/commander.go
@@ -89,34 +89,7 @@ func (c *DefaultCommander) Install(istioOperator, kubeconfig string, logger *zap
 }
 
 func (c *DefaultCommander) Upgrade(istioOperator, kubeconfig string, logger *zap.SugaredLogger) error {
-
-	kubeconfigPath, kubeconfigCf, err := file.CreateTempFileWith(kubeconfig)
-	if err != nil {
-		return err
-	}
-
-	defer func() {
-		cleanupErr := kubeconfigCf()
-		if cleanupErr != nil {
-			logger.Error(cleanupErr)
-		}
-	}()
-
-	istioOperatorPath, istioOperatorCf, err := file.CreateTempFileWith(istioOperator)
-	if err != nil {
-		return err
-	}
-
-	defer func() {
-		cleanupErr := istioOperatorCf()
-		if cleanupErr != nil {
-			logger.Error(cleanupErr)
-		}
-	}()
-
-	cmd := execCommand(c.istioctl.path, "upgrade", "-f", istioOperatorPath, "--kubeconfig", kubeconfigPath, "--skip-confirmation")
-
-	return c.execute(cmd, logger)
+	return c.Install(istioOperator, kubeconfig, logger)
 }
 
 func (c *DefaultCommander) Version(kubeconfig string, logger *zap.SugaredLogger) ([]byte, error) {

--- a/pkg/reconciler/instances/istio/istioctl/commander_test.go
+++ b/pkg/reconciler/instances/istio/istioctl/commander_test.go
@@ -81,13 +81,13 @@ func Test_DefaultCommander_Upgrade(t *testing.T) {
 	log := logger.NewLogger(false)
 	commander := DefaultCommander{}
 
-	t.Run("should run the upgrade command", func(t *testing.T) {
+	t.Run("should run the apply command", func(t *testing.T) {
 		// when
 		errors := commander.Upgrade(istioOperator, kubeconfig, log)
 
 		// then
 		require.NoError(t, errors)
-		require.EqualValues(t, testArgs[0], "upgrade")
+		require.EqualValues(t, testArgs[0], "apply")
 		require.EqualValues(t, testArgs[1], "-f")
 		require.EqualValues(t, testArgs[3], "--kubeconfig")
 		require.EqualValues(t, testArgs[5], "--skip-confirmation")


### PR DESCRIPTION
## Changes proposed

- replace usage of `istioctl upgrade` with `istioctl apply` in `DefaultCommander` implementation

## Links

See: https://github.com/kyma-incubator/reconciler/issues/917