### PR TITLE
Fix bug not adding cleaner component on deletions

### DIFF
--- a/pkg/scheduler/service/transition_test.go
+++ b/pkg/scheduler/service/transition_test.go
@@ -44,7 +44,7 @@ func TestTransition(t *testing.T) {
 	//create transition which will change cluster states
 	transition := newClusterStatusTransition(dbConn, inventory, reconRepo, logger.NewLogger(true))
 
-	testSequenceConfig := &model.ReconciliationSequenceConfig{
+	testSchedulerConfig := &SchedulerConfig{
 		PreComponents:  nil,
 		DeleteStrategy: "",
 	}
@@ -61,11 +61,11 @@ func TestTransition(t *testing.T) {
 
 	t.Run("Start Reconciliation", func(t *testing.T) {
 		oldClusterStateID := clusterState.Status.ID
-		err := transition.StartReconciliation(clusterState.Cluster.RuntimeID, clusterState.Configuration.Version, testSequenceConfig)
+		err := transition.StartReconciliation(clusterState.Cluster.RuntimeID, clusterState.Configuration.Version, testSchedulerConfig)
 		require.NoError(t, err)
 
 		//starting reconciliation twice is not allowed
-		err = transition.StartReconciliation(clusterState.Cluster.RuntimeID, clusterState.Configuration.Version, testSequenceConfig)
+		err = transition.StartReconciliation(clusterState.Cluster.RuntimeID, clusterState.Configuration.Version, testSchedulerConfig)
 		require.Error(t, err)
 
 		//verify created reconciliation
@@ -113,7 +113,10 @@ func TestTransition(t *testing.T) {
 
 	t.Run("Finish Reconciliation When Cluster is not in progress", func(t *testing.T) {
 		//get reconciliation entity
-		reconEntity, err := reconRepo.CreateReconciliation(clusterState, testSequenceConfig)
+		reconEntity, err := reconRepo.CreateReconciliation(clusterState, &model.ReconciliationSequenceConfig{
+			PreComponents:  nil,
+			DeleteStrategy: "",
+		})
 		require.NoError(t, err)
 		require.NotNil(t, reconEntity)
 		require.False(t, reconEntity.Finished)


### PR DESCRIPTION
- Fix wrong state handling when creating the reconciliation sequence causing the cleaner component to never be added.

**Related Issues**
#715