### PR TITLE
Remove reconciliations by filter

### DIFF
--- a/pkg/db/query.go
+++ b/pkg/db/query.go
@@ -3,9 +3,10 @@ package db
 import (
 	"bytes"
 	"fmt"
-	"go.uber.org/zap"
 	"sort"
 	"strings"
+
+	"go.uber.org/zap"
 )
 
 type Query struct {
@@ -38,6 +39,16 @@ func (q *Query) Select() *Select {
 	q.buffer.WriteString(fmt.Sprintf("SELECT %s FROM %s", q.columnHandler.ColumnNamesCsv(false), q.entity.Table()))
 
 	return &Select{q, []interface{}{}, nil}
+}
+
+func (q *Query) SelectColumn(fieldName string) (*Select, error) {
+	columnName, err := q.columnHandler.ColumnName(fieldName)
+	if err != nil {
+		return nil, err
+	}
+	q.buffer.WriteString(fmt.Sprintf("SELECT %s FROM %s", columnName, q.entity.Table()))
+
+	return &Select{q, []interface{}{}, nil}, nil
 }
 
 func (q *Query) Insert() *Insert {
@@ -164,6 +175,13 @@ type Select struct {
 	*Query
 	args []interface{}
 	err  error
+}
+
+//GetArgs returns a copy of current Select arguments
+func (s *Select) GetArgs() []interface{} {
+	dst := make([]interface{}, len(s.args))
+	copy(dst, s.args)
+	return dst
 }
 
 func (s *Select) WhereRaw(stmt string, args ...interface{}) *Select {

--- a/pkg/db/transaction.go
+++ b/pkg/db/transaction.go
@@ -3,13 +3,14 @@ package db
 import (
 	"database/sql"
 	"fmt"
-	"github.com/google/uuid"
-	"github.com/pkg/errors"
-	"go.uber.org/zap"
 	"math/rand"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
 )
 
 const txMaxRetries = 5
@@ -153,6 +154,7 @@ func (t *TxConnection) Query(query string, args ...interface{}) (DataRows, error
 }
 
 func (t *TxConnection) Exec(query string, args ...interface{}) (sql.Result, error) {
+	t.logger.Debugf("Transaction Exec(): %s | %v", query, args)
 	return t.tx.Exec(query, args...)
 }
 

--- a/pkg/scheduler/reconciliation/filter.go
+++ b/pkg/scheduler/reconciliation/filter.go
@@ -157,6 +157,27 @@ func (ws *WithSchedulingID) FilterByInstance(i *model.ReconciliationEntity) *mod
 	return nil
 }
 
+type WithNotSchedulingID struct {
+	SchedulingID string
+}
+
+func (wns *WithNotSchedulingID) FilterByQuery(q *db.Select) error {
+	column, err := columnName(q, "SchedulingID")
+	if err != nil {
+		return err
+	}
+
+	q.WhereRaw(fmt.Sprintf("%s<>$%d", column, q.NextPlaceholderCount()), wns.SchedulingID)
+	return nil
+}
+
+func (wns *WithNotSchedulingID) FilterByInstance(i *model.ReconciliationEntity) *model.ReconciliationEntity {
+	if i.SchedulingID != wns.SchedulingID {
+		return i
+	}
+	return nil
+}
+
 type WithRuntimeIDs struct {
 	RuntimeIDs []string
 }

--- a/pkg/scheduler/reconciliation/mock.go
+++ b/pkg/scheduler/reconciliation/mock.go
@@ -51,6 +51,10 @@ func (mr *MockRepository) RemoveReconciliationsBySchedulingID(schedulingIDs []st
 	return mr.RemoveReconciliationResult
 }
 
+func (mr *MockRepository) RemoveReconciliations(filter Filter) error {
+	return nil
+}
+
 func (mr *MockRepository) GetReconciliation(schedulingID string) (*model.ReconciliationEntity, error) {
 	return mr.GetReconciliationResult, nil
 }

--- a/pkg/scheduler/reconciliation/mock.go
+++ b/pkg/scheduler/reconciliation/mock.go
@@ -52,6 +52,11 @@ func (mr *MockRepository) RemoveReconciliationsBySchedulingID(schedulingIDs []st
 }
 
 func (mr *MockRepository) RemoveReconciliations(filter Filter) error {
+	for _, recon := range mr.GetReconciliationsResult {
+		if filter.FilterByInstance(recon) != nil {
+			mr.RemoveReconciliationRecording = append(mr.RemoveReconciliationRecording, recon.SchedulingID)
+		}
+	}
 	return nil
 }
 

--- a/pkg/scheduler/reconciliation/persistent.go
+++ b/pkg/scheduler/reconciliation/persistent.go
@@ -204,11 +204,6 @@ func (r *PersistentReconciliationRepository) RemoveReconciliations(filter Filter
 		}
 	}
 
-	// TODO: the ORM should maintain the correct SQL statement order and handle duplicated clauses.
-	if !strings.Contains(selectQ.String(), "ORDER BY") {
-		selectQ = selectQ.OrderBy(map[string]string{"Created": "DESC"})
-	}
-
 	//delete records using Select as a subquery
 	dbOps := func(tx *db.TxConnection) error {
 		//delete reconciliation

--- a/pkg/scheduler/reconciliation/persistent_test.go
+++ b/pkg/scheduler/reconciliation/persistent_test.go
@@ -106,12 +106,12 @@ func TestPersistentReconciliationRepository_RemoveReconciliationsByFilter(t *tes
 				timeToFilter := WithCreationDateBefore{
 					Time: timeTo,
 				}
-				reconciliationIdFilter := WithRuntimeID{
+				reconciliationIDFilter := WithRuntimeID{
 					RuntimeID: runtimeID,
 				}
 
 				filter := FilterMixer{
-					Filters: []Filter{&timeFromFilter, &timeToFilter, &reconciliationIdFilter},
+					Filters: []Filter{&timeFromFilter, &timeToFilter, &reconciliationIDFilter},
 				}
 
 				if err := persistenceRepo.RemoveReconciliations(&filter); (err != nil) != testCase.wantErr {

--- a/pkg/scheduler/reconciliation/reconciliation.go
+++ b/pkg/scheduler/reconciliation/reconciliation.go
@@ -2,12 +2,13 @@ package reconciliation
 
 import (
 	"fmt"
+	"sort"
+	"strings"
+
 	"github.com/kyma-incubator/reconciler/pkg/cluster"
 	"github.com/kyma-incubator/reconciler/pkg/db"
 	"github.com/kyma-incubator/reconciler/pkg/model"
 	"github.com/kyma-incubator/reconciler/pkg/scheduler/reconciliation/operation"
-	"sort"
-	"strings"
 )
 
 type metricStartTime int
@@ -22,6 +23,7 @@ type Repository interface {
 	RemoveReconciliationByRuntimeID(runtimeID string) error
 	RemoveReconciliationBySchedulingID(schedulingID string) error
 	RemoveReconciliationsBySchedulingID(schedulingIDs []string) error
+	RemoveReconciliations(filter Filter) error
 	GetReconciliation(schedulingID string) (*model.ReconciliationEntity, error)
 	GetReconciliations(filter Filter) ([]*model.ReconciliationEntity, error)
 	FinishReconciliation(schedulingID string, status *model.ClusterStatusEntity) error

--- a/pkg/scheduler/service/cleaner.go
+++ b/pkg/scheduler/service/cleaner.go
@@ -122,12 +122,12 @@ func (c *cleaner) deleteRecordsByAge(runtimeID string, numberOfDays int, transit
 	runtimeFilter := reconciliation.WithRuntimeID{
 		RuntimeID: runtimeID,
 	}
-	schedulingIdFilter := reconciliation.WithNotSchedulingID{
+	schedulingIDFilter := reconciliation.WithNotSchedulingID{
 		SchedulingID: mostRecentReconciliation.SchedulingID,
 	}
 
 	filter := reconciliation.FilterMixer{
-		Filters: []reconciliation.Filter{&timeFilter, &runtimeFilter, &schedulingIdFilter},
+		Filters: []reconciliation.Filter{&timeFilter, &runtimeFilter, &schedulingIDFilter},
 	}
 
 	return transition.ReconciliationRepository().RemoveReconciliations(&filter)

--- a/pkg/scheduler/service/cleaner.go
+++ b/pkg/scheduler/service/cleaner.go
@@ -97,6 +97,7 @@ func (c *cleaner) purgeReconciliationsForCluster(runtimeID string, transition *C
 		c.logger.Errorf("%s Failed to delete reconciliations more than %d: %s", CleanerPrefix, config.keepLatestEntitiesCount(), err.Error())
 		return
 	}
+	c.logger.Infof("%s Done cleaning reconciliation entries for cluster with RuntimeID: %s", CleanerPrefix, runtimeID)
 }
 
 //deleteRecordsByAge deletes all reconciliations for a given cluster that's older than configured number of days except the single most recent record - that one is never deleted
@@ -115,11 +116,21 @@ func (c *cleaner) deleteRecordsByAge(runtimeID string, numberOfDays int, transit
 		return nil
 	}
 
-	removeExceptOneFilter := func(m *model.ReconciliationEntity) bool {
-		return m.SchedulingID != mostRecentReconciliation.SchedulingID
+	timeFilter := reconciliation.WithCreationDateBefore{
+		Time: deadline,
+	}
+	runtimeFilter := reconciliation.WithRuntimeID{
+		RuntimeID: runtimeID,
+	}
+	schedulingIdFilter := reconciliation.WithNotSchedulingID{
+		SchedulingID: mostRecentReconciliation.SchedulingID,
 	}
 
-	return c.dropReconciliationsOlderThanByFilter(runtimeID, deadline, removeExceptOneFilter, transition)
+	filter := reconciliation.FilterMixer{
+		Filters: []reconciliation.Filter{&timeFilter, &runtimeFilter, &schedulingIdFilter},
+	}
+
+	return transition.ReconciliationRepository().RemoveReconciliations(&filter)
 }
 
 //deleteRecordsByCountAndStatus deletes record between some deadline in the past and now. It keeps the config.KeepLatestEntitiesCount() of the most recent records and the ones that are not successfully finished.
@@ -143,8 +154,6 @@ func (c *cleaner) deleteRecordsByCountAndStatus(runtimeID string, transition *Cl
 	var schedulingIDsToDrop []string
 	for _, obsoleteReconciliation := range reconciliations[mostRecentEntitiesToKeep:] {
 		if obsoleteReconciliation.Status.IsFinalStable() {
-			// collect schedulingIDs
-			// TODO: when filter for Delete statement is supported, switch back to reconciliationEntities
 			schedulingIDsToDrop = append(schedulingIDsToDrop, obsoleteReconciliation.SchedulingID)
 		}
 	}
@@ -173,42 +182,6 @@ func (c *cleaner) getMostRecentReconciliation(runtimeID string, transition *Clus
 	}
 
 	return res[0], nil
-}
-
-func (c *cleaner) dropReconciliationsOlderThanByFilter(runtimeID string, t time.Time, shouldRemoveFilter reconciliationFilter, transition *ClusterStatusTransition) error {
-	deadline := t.UTC()
-	olderReconciliations, err := c.findReconciliationsOlderThan(runtimeID, deadline, transition)
-	if err != nil {
-		return err
-	}
-
-	var schedulingIDsToDrop []string
-	for _, obsoleteReconciliation := range olderReconciliations {
-		if shouldRemoveFilter(obsoleteReconciliation) {
-			// collect schedulingIDs
-			// TODO: when filter for Delete statement is supported, switch back to reconciliationEntities
-			schedulingIDsToDrop = append(schedulingIDsToDrop, obsoleteReconciliation.SchedulingID)
-		}
-	}
-
-	c.logger.Infof("%s Found %d records older than %s for cluster %s", CleanerPrefix, len(schedulingIDsToDrop), deadline.String(), runtimeID)
-	if len(schedulingIDsToDrop) > 0 {
-		return c.removeReconciliations(schedulingIDsToDrop, transition)
-	}
-	return err
-}
-
-func (c *cleaner) findReconciliationsOlderThan(runtimeID string, t time.Time, transition *ClusterStatusTransition) ([]*model.ReconciliationEntity, error) {
-	runtimeIDFilter := reconciliation.WithRuntimeID{RuntimeID: runtimeID}
-	dateBeforeFilter := reconciliation.WithCreationDateBefore{Time: t}
-	filter := reconciliation.FilterMixer{Filters: []reconciliation.Filter{&runtimeIDFilter, &dateBeforeFilter}}
-
-	reconciliations, err := transition.ReconciliationRepository().GetReconciliations(&filter)
-	if err != nil {
-		c.logger.Errorf("%s Failed to get reconciliations older than %s: %s", CleanerPrefix, t.String(), err.Error())
-		return nil, err
-	}
-	return reconciliations, nil
 }
 
 //removeReconciliations drops all reconciliations provided in the list
@@ -246,5 +219,3 @@ func (c *cleaner) purgeReconciliationsOld(transition *ClusterStatusTransition, c
 func beginningOfTheDay(t time.Time) time.Time {
 	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
 }
-
-type reconciliationFilter func(*model.ReconciliationEntity) bool

--- a/pkg/scheduler/service/cleaner_test.go
+++ b/pkg/scheduler/service/cleaner_test.go
@@ -68,56 +68,67 @@ func Test_cleaner_Run(t *testing.T) {
 
 		reconciliations := []*model.ReconciliationEntity{
 			{
+				RuntimeID:    "test-cluster",
 				SchedulingID: "test-id-0",
 				Created:      start,
 				Status:       model.ClusterStatusReady,
 			},
 			{
+				RuntimeID:    "test-cluster",
 				SchedulingID: "test-id-1",
 				Created:      start.Add((-1 * 24) * time.Hour),
 				Status:       model.ClusterStatusReconcileErrorRetryable,
 			},
 			{
+				RuntimeID:    "test-cluster",
 				SchedulingID: "test-id-2",
 				Created:      start.Add((-2 * 24) * time.Hour),
 				Status:       model.ClusterStatusReady,
 			},
 			{
+				RuntimeID:    "test-cluster",
 				SchedulingID: "test-id-3",
 				Created:      start.Add((-3 * 24) * time.Hour),
 				Status:       model.ClusterStatusReconcileErrorRetryable,
 			},
 			{
+				RuntimeID:    "test-cluster",
 				SchedulingID: "test-id-4",
 				Created:      start.Add((-4 * 24) * time.Hour),
 				Status:       model.ClusterStatusReady,
 			},
 			{
+				RuntimeID:    "test-cluster",
 				SchedulingID: "test-id-5",
 				Created:      start.Add((-5 * 24) * time.Hour),
 				Status:       model.ClusterStatusReconcileErrorRetryable,
 			},
 			{
+				RuntimeID:    "test-cluster",
 				SchedulingID: "test-id-6",
 				Created:      start.Add((-6 * 24) * time.Hour),
 				Status:       model.ClusterStatusReady,
 			},
 			{
+				RuntimeID:    "test-cluster",
 				SchedulingID: "test-id-7",
 				Created:      start.Add((-7 * 24) * time.Hour),
 				Status:       model.ClusterStatusReconcileErrorRetryable,
 			},
 			{
+				RuntimeID:    "test-cluster",
 				SchedulingID: "test-id-8",
 				Created:      start.Add((-8 * 24) * time.Hour),
 				Status:       model.ClusterStatusReady,
 			},
 			{
+				RuntimeID:    "test-cluster",
 				SchedulingID: "test-id-9",
 				Created:      start.Add((-9 * 24) * time.Hour),
 				Status:       model.ClusterStatusReconcileErrorRetryable,
 			},
 			{
+				RuntimeID:    "test-cluster",
 				SchedulingID: "test-id-10",
 				Created:      start.Add((-10 * 24) * time.Hour),
 				Status:       model.ClusterStatusReady,
@@ -125,14 +136,11 @@ func Test_cleaner_Run(t *testing.T) {
 		}
 
 		updateModel := func(repo *reconciliation.MockRepository) {
-			if (repo.GetReconciliationsCount) == 1 {
-				repo.GetReconciliationsResult = []*model.ReconciliationEntity{reconciliations[7], reconciliations[8], reconciliations[9], reconciliations[10]} //setup data for the second call for reconciliations older that 6 days (from now)
+			if repo.GetReconciliationsCount == 1 {
+				repo.GetReconciliationsResult = reconciliations
+			} else if repo.GetReconciliationsCount == 2 {
+				repo.GetReconciliationsResult = reconciliations[0:6]
 			}
-
-			if (repo.GetReconciliationsCount) == 2 {
-				repo.GetReconciliationsResult = []*model.ReconciliationEntity{reconciliations[0], reconciliations[1], reconciliations[2], reconciliations[3], reconciliations[4], reconciliations[5], reconciliations[6]} //setup data for the third call for remaining reconciliations (between now and 6 days ago)
-			}
-
 		}
 
 		reconRepo := reconciliation.MockRepository{
@@ -153,7 +161,7 @@ func Test_cleaner_Run(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, 3, reconRepo.GetReconciliationsCount)
+		require.Equal(t, 2, reconRepo.GetReconciliationsCount)
 		recordedIDs := reconRepo.RemoveReconciliationRecording
 
 		//First batch of removals comes from "deleteRecordsByAge"


### PR DESCRIPTION
**Description**

Add a "bulk delete"  feature to the reconciliations repository in order to optimize cleaner module performance.

The new function accepts a select-filter (or combination of such filters) to delete records in one shot using DELETE statement without loading the data into reconciler's process memory.
The direct use case for this feature is to remove all records older than certain date except a single most-recent one, even if it matches the "older than" condition - see: https://github.com/kyma-incubator/reconciler/issues/884

**Changes**
- extend reconciliation.Repository interface with `RemoveReconciliations(filter Filter) error` function
- provide necessary implementations for SQL and in-memory repositories.
- extend logging in TxConnection.Exec() function to debug-level logging of transactional SQL statements like "DELETE"
- improve cleaner deletion logic with the new feature

**See also**
https://github.com/kyma-incubator/reconciler/pull/912