### PR TITLE
increase startup shift for hydra maester pod

### DIFF
--- a/pkg/reconciler/instances/ory/hydra/syncer.go
+++ b/pkg/reconciler/instances/ory/hydra/syncer.go
@@ -35,7 +35,7 @@ const (
 	hydraPodName           = "app.kubernetes.io/name=hydra"
 	hydraMaesterPodName    = "app.kubernetes.io/name=hydra-maester"
 	hydraMaesterDeployment = "ory-hydra-maester"
-	startupShift           = -2 * time.Second
+	startupShift           = -30 * time.Second
 )
 
 func (c *DefaultHydraSyncer) TriggerSynchronization(context context.Context, client internalKubernetes.Client, logger *zap.SugaredLogger, namespace string, forceSync bool) error {

--- a/pkg/reconciler/instances/ory/hydra/syncer.go
+++ b/pkg/reconciler/instances/ory/hydra/syncer.go
@@ -35,7 +35,7 @@ const (
 	hydraPodName           = "app.kubernetes.io/name=hydra"
 	hydraMaesterPodName    = "app.kubernetes.io/name=hydra-maester"
 	hydraMaesterDeployment = "ory-hydra-maester"
-	startupShift           = -30 * time.Second
+	startupShift           = -60 * time.Second
 )
 
 func (c *DefaultHydraSyncer) TriggerSynchronization(context context.Context, client internalKubernetes.Client, logger *zap.SugaredLogger, namespace string, forceSync bool) error {


### PR DESCRIPTION
Increase time shift interval for determination if a hydra synchronization needs to be triggered, as the missing synchronization  causes missing OAuth2Clients within hydra.
https://github.com/kyma-project/kyma/issues/13498
