### PR TITLE
Remove reconciliations by runtimeID

### DIFF
--- a/cmd/mothership/mothership/start/integration_test.go
+++ b/cmd/mothership/mothership/start/integration_test.go
@@ -546,7 +546,7 @@ func removeExistingReconciliations(t *testing.T, repo reconciliation.Repository)
 	recons, err := repo.GetReconciliations(nil)
 	require.NoError(t, err)
 	for _, recon := range recons {
-		require.NoError(t, repo.RemoveReconciliation(recon.SchedulingID))
+		require.NoError(t, repo.RemoveReconciliationBySchedulingID(recon.SchedulingID))
 	}
 }
 

--- a/pkg/scheduler/reconciliation/inmemory.go
+++ b/pkg/scheduler/reconciliation/inmemory.go
@@ -92,7 +92,7 @@ func (r *InMemoryReconciliationRepository) CreateReconciliation(state *cluster.S
 	return reconEntity, nil
 }
 
-func (r *InMemoryReconciliationRepository) RemoveReconciliation(schedulingID string) error {
+func (r *InMemoryReconciliationRepository) RemoveReconciliationBySchedulingID(schedulingID string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -100,14 +100,16 @@ func (r *InMemoryReconciliationRepository) RemoveReconciliation(schedulingID str
 	return nil
 }
 
-func (r *InMemoryReconciliationRepository) RemoveReconciliations(schedulingIDs []string) error {
+func (r *InMemoryReconciliationRepository) RemoveReconciliationsBySchedulingID(schedulingIDs []string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-
 	for _, schedulingID := range schedulingIDs {
 		removeSchedulingID(schedulingID, r.reconciliations, r.operations)
 	}
-
+	return nil
+}
+func (r *InMemoryReconciliationRepository) RemoveReconciliationByRuntimeID(runtimeID string) error {
+	// TODO: implement
 	return nil
 }
 

--- a/pkg/scheduler/reconciliation/inmemory.go
+++ b/pkg/scheduler/reconciliation/inmemory.go
@@ -95,7 +95,6 @@ func (r *InMemoryReconciliationRepository) CreateReconciliation(state *cluster.S
 func (r *InMemoryReconciliationRepository) RemoveReconciliationBySchedulingID(schedulingID string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-
 	removeSchedulingID(schedulingID, r.reconciliations, r.operations)
 	return nil
 }
@@ -109,7 +108,16 @@ func (r *InMemoryReconciliationRepository) RemoveReconciliationsBySchedulingID(s
 	return nil
 }
 func (r *InMemoryReconciliationRepository) RemoveReconciliationByRuntimeID(runtimeID string) error {
-	// TODO: implement
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var schedulingID string
+	if r.reconciliations[runtimeID] != nil {
+		schedulingID = r.reconciliations[runtimeID].SchedulingID
+	}
+	delete(r.reconciliations, runtimeID)
+	delete(r.operations, schedulingID)
+
 	return nil
 }
 

--- a/pkg/scheduler/reconciliation/mock.go
+++ b/pkg/scheduler/reconciliation/mock.go
@@ -36,8 +36,13 @@ func (mr *MockRepository) CreateReconciliation(state *cluster.State, cfg *model.
 	return mr.CreateReconciliationResult, nil
 }
 
-func (mr *MockRepository) RemoveReconciliation(schedulingID string) error {
+func (mr *MockRepository) RemoveReconciliationBySchedulingID(schedulingID string) error {
 	mr.RemoveReconciliationRecording = append(mr.RemoveReconciliationRecording, schedulingID)
+	return mr.RemoveReconciliationResult
+}
+
+func (mr *MockRepository) RemoveReconciliationByRuntimeID(runtimeID string) error {
+	mr.RemoveReconciliationRecording = append(mr.RemoveReconciliationRecording, runtimeID)
 	return mr.RemoveReconciliationResult
 }
 
@@ -106,6 +111,6 @@ func (mr *MockRepository) GetAllComponents() ([]string, error) {
 	return mr.GetAllComponentsResult, mr.GetAllComponentsResultError
 }
 
-func (mr *MockRepository) RemoveReconciliations(schedulingIDs []string) error {
+func (mr *MockRepository) RemoveReconciliationsBySchedulingID(schedulingIDs []string) error {
 	return nil
 }

--- a/pkg/scheduler/reconciliation/persistent_test.go
+++ b/pkg/scheduler/reconciliation/persistent_test.go
@@ -66,7 +66,7 @@ func prepareTest(t *testing.T, schedulingIDsCount int) (Repository, Repository, 
 	return persistenceRepo, inMemoryRepo, persistenceSchedulingIDs, inMemorySchedulingIDs
 }
 
-func TestPersistentReconciliationRepository_RemoveSchedulingIds(t *testing.T) {
+func TestPersistentReconciliationRepository_RemoveReconciliationsBySchedulingID(t *testing.T) {
 	dbConn = dbConnection(t)
 
 	tests := []struct {
@@ -100,10 +100,10 @@ func TestPersistentReconciliationRepository_RemoveSchedulingIds(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			persistenceRepo, inMemoryRepo, persistenceSchedulingIDs, inMemorySchedulingIDs := prepareTest(t, testCase.reconciliations)
 
-			if err := persistenceRepo.RemoveReconciliations(persistenceSchedulingIDs); (err != nil) != testCase.wantErr {
+			if err := persistenceRepo.RemoveReconciliationsBySchedulingID(persistenceSchedulingIDs); (err != nil) != testCase.wantErr {
 				t.Errorf("Persistence RemoveSchedulingIds() error = %v, wantErr %v", err, testCase.wantErr)
 			}
-			if err := inMemoryRepo.RemoveReconciliations(inMemorySchedulingIDs); (err != nil) != testCase.wantErr {
+			if err := inMemoryRepo.RemoveReconciliationsBySchedulingID(inMemorySchedulingIDs); (err != nil) != testCase.wantErr {
 				t.Errorf("InMemory RemoveSchedulingIds() error = %v, wantErr %v", err, testCase.wantErr)
 			}
 

--- a/pkg/scheduler/reconciliation/reconciliation.go
+++ b/pkg/scheduler/reconciliation/reconciliation.go
@@ -19,8 +19,9 @@ const (
 
 type Repository interface {
 	CreateReconciliation(state *cluster.State, cfg *model.ReconciliationSequenceConfig) (*model.ReconciliationEntity, error)
-	RemoveReconciliation(schedulingID string) error
-	RemoveReconciliations(schedulingIDs []string) error
+	RemoveReconciliationByRuntimeID(runtimeID string) error
+	RemoveReconciliationBySchedulingID(schedulingID string) error
+	RemoveReconciliationsBySchedulingID(schedulingIDs []string) error
 	GetReconciliation(schedulingID string) (*model.ReconciliationEntity, error)
 	GetReconciliations(filter Filter) ([]*model.ReconciliationEntity, error)
 	FinishReconciliation(schedulingID string, status *model.ClusterStatusEntity) error

--- a/pkg/scheduler/reconciliation/reconciliation_test.go
+++ b/pkg/scheduler/reconciliation/reconciliation_test.go
@@ -356,11 +356,11 @@ func TestReconciliationRepository(t *testing.T) {
 				reconEntity, err := reconRepo.CreateReconciliation(stateMock1, &model.ReconciliationSequenceConfig{})
 				require.NoError(t, err)
 
-				err = reconRepo.RemoveReconciliation(reconEntity.SchedulingID)
+				err = reconRepo.RemoveReconciliationBySchedulingID(reconEntity.SchedulingID)
 				require.NoError(t, err)
 
 				//try to delete non-exiting reconciliation (no error expected)
-				err = reconRepo.RemoveReconciliation("123-456")
+				err = reconRepo.RemoveReconciliationBySchedulingID("123-456")
 				require.NoError(t, err)
 			},
 		},
@@ -393,7 +393,7 @@ func TestReconciliationRepository(t *testing.T) {
 				require.Equal(t, opsEntities[1], op)
 
 				//ensure also operations are dropped
-				err = reconRepo.RemoveReconciliation(reconEntity.SchedulingID)
+				err = reconRepo.RemoveReconciliationBySchedulingID(reconEntity.SchedulingID)
 				require.NoError(t, err)
 
 				opsEntities, err = reconRepo.GetOperations(&operation.WithSchedulingID{
@@ -763,7 +763,7 @@ func removeExistingReconciliations(t *testing.T, repos map[string]Repository) {
 		recons, err := repo.GetReconciliations(nil)
 		require.NoError(t, err)
 		for _, recon := range recons {
-			require.NoError(t, repo.RemoveReconciliation(recon.SchedulingID))
+			require.NoError(t, repo.RemoveReconciliationBySchedulingID(recon.SchedulingID))
 		}
 	}
 }

--- a/pkg/scheduler/service/bookkeeper_test.go
+++ b/pkg/scheduler/service/bookkeeper_test.go
@@ -74,6 +74,6 @@ func TestBookkeeper(t *testing.T) {
 	recons, err := reconRepo.GetReconciliations(&reconciliation.WithRuntimeID{RuntimeID: clusterState.Cluster.RuntimeID})
 	require.NoError(t, err)
 	for _, recon := range recons {
-		require.NoError(t, reconRepo.RemoveReconciliation(recon.SchedulingID))
+		require.NoError(t, reconRepo.RemoveReconciliationBySchedulingID(recon.SchedulingID))
 	}
 }

--- a/pkg/scheduler/service/bookkeepingtask_test.go
+++ b/pkg/scheduler/service/bookkeepingtask_test.go
@@ -264,6 +264,6 @@ func removeExistingReconciliations(t *testing.T, repo reconciliation.Repository)
 	recons, err := repo.GetReconciliations(nil)
 	require.NoError(t, err)
 	for _, recon := range recons {
-		require.NoError(t, repo.RemoveReconciliation(recon.SchedulingID))
+		require.NoError(t, repo.RemoveReconciliationBySchedulingID(recon.SchedulingID))
 	}
 }

--- a/pkg/scheduler/service/cleaner.go
+++ b/pkg/scheduler/service/cleaner.go
@@ -217,7 +217,7 @@ func (c *cleaner) removeReconciliations(list []*model.ReconciliationEntity, tran
 	for _, r := range list {
 		id := r.SchedulingID
 
-		err := transition.ReconciliationRepository().RemoveReconciliation(id)
+		err := transition.ReconciliationRepository().RemoveReconciliationBySchedulingID(id)
 		c.logger.Debugf("[CLEANER] removing reconciliation %s for a cluster: %s", r.SchedulingID, r.RuntimeID)
 		if err == nil {
 			cnt++
@@ -246,8 +246,8 @@ func (c *cleaner) purgeReconciliationsOld(transition *ClusterStatusTransition, c
 			"(created: %s)", reconciliations[i].SchedulingID, reconciliations[i].Created)
 
 		id := reconciliations[i].SchedulingID
-		err := transition.ReconciliationRepository().RemoveReconciliation(id)
-		c.logger.Debugf("[CLEANER] transition.ReconciliationRepository().RemoveReconciliation(%s)", id)
+		err := transition.ReconciliationRepository().RemoveReconciliationBySchedulingID(id)
+		c.logger.Debugf("[CLEANER] transition.ReconciliationRepository().RemoveReconciliationBySchedulingID(%s)", id)
 		if err != nil {
 			c.logger.Errorf("Cleaner failed to remove reconciliation with schedulingID '%s': %s", id, err.Error())
 		}

--- a/pkg/scheduler/service/run_test.go
+++ b/pkg/scheduler/service/run_test.go
@@ -107,7 +107,7 @@ func runRemote(t *testing.T, expectedClusterStatus model.Status, timeout time.Du
 		recons, err := reconRepo.GetReconciliations(&reconciliation.WithRuntimeID{RuntimeID: clusterState.Cluster.RuntimeID})
 		require.NoError(t, err)
 		for _, recon := range recons {
-			require.NoError(t, reconRepo.RemoveReconciliation(recon.SchedulingID))
+			require.NoError(t, reconRepo.RemoveReconciliationBySchedulingID(recon.SchedulingID))
 		}
 	}()
 

--- a/pkg/scheduler/service/transition_test.go
+++ b/pkg/scheduler/service/transition_test.go
@@ -55,7 +55,7 @@ func TestTransition(t *testing.T) {
 		recons, err := reconRepo.GetReconciliations(&reconciliation.WithRuntimeID{RuntimeID: clusterState.Cluster.RuntimeID})
 		require.NoError(t, err)
 		for _, recon := range recons {
-			require.NoError(t, reconRepo.RemoveReconciliation(recon.SchedulingID))
+			require.NoError(t, reconRepo.RemoveReconciliationBySchedulingID(recon.SchedulingID))
 		}
 	}()
 

--- a/pkg/scheduler/worker/workerpool_test.go
+++ b/pkg/scheduler/worker/workerpool_test.go
@@ -141,7 +141,7 @@ func TestWorkerPoolMaxOpRetriesReached(t *testing.T) {
 	reconEntity, err := testInvoker.reconRepo.CreateReconciliation(clusterState, &model.ReconciliationSequenceConfig{})
 	require.NoError(t, err)
 	defer func() { //cleanup at the end of the execution
-		require.NoError(t, testInvoker.reconRepo.RemoveReconciliation(reconEntity.SchedulingID))
+		require.NoError(t, testInvoker.reconRepo.RemoveReconciliationBySchedulingID(reconEntity.SchedulingID))
 	}()
 
 	maxParallelOps := 25
@@ -246,7 +246,7 @@ func TestWorkerPoolParallel(t *testing.T) {
 
 		defer func() { //cleanup at the end of the test execution
 			for _, recon := range recons {
-				require.NoError(t, testInvoker.reconRepo.RemoveReconciliation(recon.SchedulingID))
+				require.NoError(t, testInvoker.reconRepo.RemoveReconciliationBySchedulingID(recon.SchedulingID))
 			}
 		}()
 


### PR DESCRIPTION
- Adds functionality to remove reconciliations by runtimeID
- Rename previous removeReconciliation() -> removeReconciliationsBySchedulingID(), removeReconciliations() -> removeReconciliationsBySchedulingID()
- Test removeReconciliationsBySchedulingID() and removeReconciliationsBySchedulingID()