### PR TITLE
Fix metrics unit mismatch

### DIFF
--- a/pkg/metrics/component_processing_duration.go
+++ b/pkg/metrics/component_processing_duration.go
@@ -19,7 +19,7 @@ func NewComponentProcessingDurationMetric(logger *zap.SugaredLogger) *ComponentP
 			Subsystem: prometheusSubsystem,
 			Name:      "processing_time",
 			Help:      "Processing time of operations",
-			Buckets:   prometheus.ExponentialBuckets(startBucketWithMillisecond, 2, 10),
+			Buckets:   prometheus.ExponentialBuckets(startBucketWithMillisecond, 2, 11),
 		}, []string{"component", "metric"}),
 		logger: logger,
 	}


### PR DESCRIPTION
`time.Duration` is nanosecond, this PR fix the conversion between millisecond and nanosecond