### PR TITLE
Use semicolon instead of colon to seperate paths to support windows 

### DIFF
--- a/Dockerfile.cr
+++ b/Dockerfile.cr
@@ -39,7 +39,7 @@ COPY --from=build /configs/ /configs/
 # Add istioctl tools
 COPY --from=istio-1_11_4 /usr/local/bin/istioctl /bin/istioctl-1.11.4
 COPY --from=istio-1_12_3 /usr/local/bin/istioctl /bin/istioctl-1.12.3
-# For multiple istioctl binaries, provide their paths separated with a colon (:) like in the Linux PATH variable.
+# For multiple istioctl binaries, provide their paths separated with a semicolon (;) like in the Linux PATH variable.
 ENV ISTIOCTL_PATH=/bin/istioctl-1.12.3;/bin/istioctl-1.11.4
 
 USER appuser:appuser

--- a/Dockerfile.cr
+++ b/Dockerfile.cr
@@ -40,7 +40,7 @@ COPY --from=build /configs/ /configs/
 COPY --from=istio-1_11_4 /usr/local/bin/istioctl /bin/istioctl-1.11.4
 COPY --from=istio-1_12_3 /usr/local/bin/istioctl /bin/istioctl-1.12.3
 # For multiple istioctl binaries, provide their paths separated with a colon (:) like in the Linux PATH variable.
-ENV ISTIOCTL_PATH=/bin/istioctl-1.12.3:/bin/istioctl-1.11.4
+ENV ISTIOCTL_PATH=/bin/istioctl-1.12.3;/bin/istioctl-1.11.4
 
 USER appuser:appuser
 

--- a/pkg/reconciler/instances/istio/bootstrap.go
+++ b/pkg/reconciler/instances/istio/bootstrap.go
@@ -32,7 +32,7 @@ func istioPerformerCreator(istioProxyReset proxy.IstioProxyReset, provider clien
 
 		resolver, err := newDefaultCommanderResolver(istioctlPaths, logger)
 		if err != nil {
-			logger.Errorf("Could not create '%s' component reconciler: Error parsing env variable '%s': %s", name, istioctlBinaryPathEnvKey, err.Error())
+			logger.Errorf("Could not create '%s' component reconciler: Error creating DefaultCOmmadnerResolver with istioctLPaths '%s': %s", name, istioctlPaths, err.Error())
 			return nil, err
 		}
 
@@ -75,7 +75,7 @@ func newDefaultCommanderResolver(paths []string, log *zap.SugaredLogger) (action
 	}, nil
 }
 
-// parsePaths func parses and validates executable paths. The input must contain a list of full/absolute filesystem paths of binaries, separated by a colon character ':'
+// parsePaths func parses and validates executable paths. The input must contain a list of full/absolute filesystem paths of binaries, separated by a semicolon character ';'
 // isValid function is used to validate every single binary path in the input.
 func parsePaths(input string, isValid func(string) error) ([]string, error) {
 	trimmed := strings.TrimSpace(input)
@@ -85,7 +85,7 @@ func parsePaths(input string, isValid func(string) error) ([]string, error) {
 	if len(trimmed) > istioctlBinaryPathMaxLen {
 		return nil, errors.New(fmt.Sprintf("%s env variable exceeds the maximum istio path limit of %d characters", istioctlBinaryPathEnvKey, istioctlBinaryPathMaxLen))
 	}
-	pathDefs := strings.Split(trimmed, ":")
+	pathDefs := strings.Split(trimmed, ";")
 	var res []string
 	for _, path := range pathDefs {
 		val := strings.TrimSpace(path)

--- a/pkg/reconciler/instances/istio/bootstrap.go
+++ b/pkg/reconciler/instances/istio/bootstrap.go
@@ -24,7 +24,7 @@ func istioPerformerCreator(istioProxyReset proxy.IstioProxyReset, provider clien
 
 	res := func(logger *zap.SugaredLogger) (actions.IstioPerformer, error) {
 		pathsConfig := os.Getenv(istioctlBinaryPathEnvKey)
-		istioctlPaths, err := parsePaths(pathsConfig, validatePath, logger)
+		istioctlPaths, err := parsePaths(pathsConfig, ensureFileExecutable, logger)
 		if err != nil {
 			logger.Errorf("Could not create '%s' component reconciler: Error parsing env variable '%s': %s", name, istioctlBinaryPathEnvKey, err.Error())
 			return nil, err
@@ -100,7 +100,7 @@ func parsePaths(input string, isValid func(string, *zap.SugaredLogger) error, lo
 	return res, nil
 }
 
-func validatePath(path string, logger *zap.SugaredLogger) error {
+func ensureFileExecutable(path string, logger *zap.SugaredLogger) error {
 	stat, err := os.Stat(path)
 	if err != nil {
 		return errors.Wrap(err, "Error getting file data")

--- a/pkg/reconciler/instances/istio/bootstrap.go
+++ b/pkg/reconciler/instances/istio/bootstrap.go
@@ -32,7 +32,7 @@ func istioPerformerCreator(istioProxyReset proxy.IstioProxyReset, provider clien
 
 		resolver, err := newDefaultCommanderResolver(istioctlPaths, logger)
 		if err != nil {
-			logger.Errorf("Could not create '%s' component reconciler: Error creating DefaultCommadnerResolver with istioctLPaths '%s': %s", name, istioctlPaths, err.Error())
+			logger.Errorf("Could not create '%s' component reconciler: Error creating DefaultCommanderResolver with istioctlPaths '%s': %s", name, istioctlPaths, err.Error())
 			return nil, err
 		}
 

--- a/pkg/reconciler/instances/istio/bootstrap.go
+++ b/pkg/reconciler/instances/istio/bootstrap.go
@@ -24,7 +24,7 @@ func istioPerformerCreator(istioProxyReset proxy.IstioProxyReset, provider clien
 
 	res := func(logger *zap.SugaredLogger) (actions.IstioPerformer, error) {
 		pathsConfig := os.Getenv(istioctlBinaryPathEnvKey)
-		istioctlPaths, err := parsePaths(pathsConfig, validatePath)
+		istioctlPaths, err := parsePaths(pathsConfig, validatePath, logger)
 		if err != nil {
 			logger.Errorf("Could not create '%s' component reconciler: Error parsing env variable '%s': %s", name, istioctlBinaryPathEnvKey, err.Error())
 			return nil, err
@@ -77,7 +77,7 @@ func newDefaultCommanderResolver(paths []string, log *zap.SugaredLogger) (action
 
 // parsePaths func parses and validates executable paths. The input must contain a list of full/absolute filesystem paths of binaries, separated by a semicolon character ';'
 // isValid function is used to validate every single binary path in the input.
-func parsePaths(input string, isValid func(string, *zap.SugaredLogger) error) ([]string, error) {
+func parsePaths(input string, isValid func(string, *zap.SugaredLogger) error, logger *zap.SugaredLogger) ([]string, error) {
 	trimmed := strings.TrimSpace(input)
 	if trimmed == "" {
 		return nil, errors.Errorf("%s env variable is undefined or empty", istioctlBinaryPathEnvKey)
@@ -92,7 +92,7 @@ func parsePaths(input string, isValid func(string, *zap.SugaredLogger) error) ([
 		if val == "" {
 			return nil, errors.New("Invalid (empty) path provided")
 		}
-		if err := isValid(val); err != nil {
+		if err := isValid(val, logger); err != nil {
 			return nil, err
 		}
 		res = append(res, val)

--- a/pkg/reconciler/instances/istio/bootstrap.go
+++ b/pkg/reconciler/instances/istio/bootstrap.go
@@ -112,7 +112,11 @@ func validatePath(path string, logger *zap.SugaredLogger) error {
 		return errors.New(fmt.Sprintf("\"%s\" is not a regular file", path))
 	}
 	if uint32(mode&0111) == 0 {
-		return errors.New(fmt.Sprintf("\"%s\" is not executable", path))
+		var fileMode os.FileMode = 0777
+		if err := os.Chmod(path, fileMode); err != nil {
+			return errors.Wrap(err, fmt.Sprintf("%s is not executable - Failed to change file mode of istioctl binary to: %s", path, fileMode))
+		}
+		logger.Debugf("%s chmod to: %s", path, fileMode)
 	}
 
 	return nil

--- a/pkg/reconciler/instances/istio/bootstrap.go
+++ b/pkg/reconciler/instances/istio/bootstrap.go
@@ -112,7 +112,8 @@ func validatePath(path string, logger *zap.SugaredLogger) error {
 	}
 	if uint32(mode&0111) == 0 {
 		logger.Debugf("%s is not executable, will chmod +x", path)
-		if err := chmodExecutbale(path, logger); err != nil {
+		err := chmodExecutbale(path, logger)
+		if err != nil {
 			return err
 		}
 	}

--- a/pkg/reconciler/instances/istio/bootstrap.go
+++ b/pkg/reconciler/instances/istio/bootstrap.go
@@ -32,7 +32,7 @@ func istioPerformerCreator(istioProxyReset proxy.IstioProxyReset, provider clien
 
 		resolver, err := newDefaultCommanderResolver(istioctlPaths, logger)
 		if err != nil {
-			logger.Errorf("Could not create '%s' component reconciler: Error creating DefaultCOmmadnerResolver with istioctLPaths '%s': %s", name, istioctlPaths, err.Error())
+			logger.Errorf("Could not create '%s' component reconciler: Error creating DefaultCommadnerResolver with istioctLPaths '%s': %s", name, istioctlPaths, err.Error())
 			return nil, err
 		}
 
@@ -77,7 +77,7 @@ func newDefaultCommanderResolver(paths []string, log *zap.SugaredLogger) (action
 
 // parsePaths func parses and validates executable paths. The input must contain a list of full/absolute filesystem paths of binaries, separated by a semicolon character ';'
 // isValid function is used to validate every single binary path in the input.
-func parsePaths(input string, isValid func(string) error) ([]string, error) {
+func parsePaths(input string, isValid func(string, *zap.SugaredLogger) error) ([]string, error) {
 	trimmed := strings.TrimSpace(input)
 	if trimmed == "" {
 		return nil, errors.Errorf("%s env variable is undefined or empty", istioctlBinaryPathEnvKey)
@@ -101,12 +101,13 @@ func parsePaths(input string, isValid func(string) error) ([]string, error) {
 }
 
 // TODO: test it
-func validatePath(path string) error {
+func validatePath(path string, logger *zap.SugaredLogger) error {
 	stat, err := os.Stat(path)
 	if err != nil {
 		return errors.Wrap(err, "Error getting file data")
 	}
 	mode := stat.Mode()
+	logger.Debugf("%s mode: %s", path, mode)
 	if (!mode.IsRegular()) || mode.IsDir() {
 		return errors.New(fmt.Sprintf("\"%s\" is not a regular file", path))
 	}

--- a/pkg/reconciler/instances/istio/bootstrap_test.go
+++ b/pkg/reconciler/instances/istio/bootstrap_test.go
@@ -123,7 +123,7 @@ func TestParsePaths(t *testing.T) {
 }
 
 func TestChmodExecutable(t *testing.T) {
-	t.Run("chmod to 0777", func(t *testing.T) {
+	t.Run("should return nil and change mode of file to 0777 when it had 0000", func(t *testing.T) {
 		pathToFile := "tmp/dat1"
 		t.Cleanup(func() {
 			err := os.RemoveAll("tmp")
@@ -151,7 +151,7 @@ func TestChmodExecutable(t *testing.T) {
 	})
 }
 
-func TestValidatePath(t *testing.T) {
+func TestEnsureFileExecutable(t *testing.T) {
 	t.Run("should return nil and change mode of file to 0777 when it had 0000", func(t *testing.T) {
 		pathToFile := "tmp/dat1"
 		t.Cleanup(func() {
@@ -162,7 +162,7 @@ func TestValidatePath(t *testing.T) {
 		d1 := []byte("hello\nworld\n")
 		err := os.WriteFile(pathToFile, d1, 0000)
 		require.NoError(t, err)
-		err = validatePath(pathToFile, zap.NewNop().Sugar())
+		err = ensureFileExecutable(pathToFile, zap.NewNop().Sugar())
 		require.NoError(t, err)
 		stat, err := os.Stat(pathToFile)
 		require.NoError(t, err)
@@ -171,12 +171,12 @@ func TestValidatePath(t *testing.T) {
 	})
 	t.Run("should return error when file does not exist", func(t *testing.T) {
 		pathToFile := "not-existing"
-		err := validatePath(pathToFile, zap.NewNop().Sugar())
+		err := ensureFileExecutable(pathToFile, zap.NewNop().Sugar())
 		require.Error(t, err)
 	})
 	t.Run("should return error when path is empty", func(t *testing.T) {
 		pathToFile := ""
-		err := validatePath(pathToFile, zap.NewNop().Sugar())
+		err := ensureFileExecutable(pathToFile, zap.NewNop().Sugar())
 		require.Error(t, err)
 	})
 }

--- a/pkg/reconciler/instances/istio/bootstrap_test.go
+++ b/pkg/reconciler/instances/istio/bootstrap_test.go
@@ -124,6 +124,7 @@ func TestParsePaths(t *testing.T) {
 
 func TestChmodExecutable(t *testing.T) {
 	t.Run("should return nil and change mode of file to 0777 when it had 0000", func(t *testing.T) {
+		//given
 		pathToFile := "tmp/dat1"
 		t.Cleanup(func() {
 			err := os.RemoveAll("tmp")
@@ -133,26 +134,35 @@ func TestChmodExecutable(t *testing.T) {
 		d1 := []byte("hello\nworld\n")
 		err := os.WriteFile(pathToFile, d1, 0000)
 		require.NoError(t, err)
+		//when
 		err = chmodExecutbale(pathToFile, zap.NewNop().Sugar())
 		require.NoError(t, err)
+		//then
 		stat, err := os.Stat(pathToFile)
 		require.NoError(t, err)
 		require.Equal(t, os.FileMode(0777), stat.Mode())
 	})
 	t.Run("should return an error when file does not exist", func(t *testing.T) {
+		//given
 		pathToFile := "not-existing"
+		//when
 		err := chmodExecutbale(pathToFile, zap.NewNop().Sugar())
+		//then
 		require.Error(t, err)
 	})
 	t.Run("should return an error when path to file is empty", func(t *testing.T) {
+		//given
 		pathToFile := ""
+		//when
 		err := chmodExecutbale(pathToFile, zap.NewNop().Sugar())
+		//then
 		require.Error(t, err)
 	})
 }
 
 func TestEnsureFileExecutable(t *testing.T) {
 	t.Run("should return nil and change mode of file to 0777 when it had 0000", func(t *testing.T) {
+		//given
 		pathToFile := "tmp/dat1"
 		t.Cleanup(func() {
 			err := os.RemoveAll("tmp")
@@ -162,21 +172,29 @@ func TestEnsureFileExecutable(t *testing.T) {
 		d1 := []byte("hello\nworld\n")
 		err := os.WriteFile(pathToFile, d1, 0000)
 		require.NoError(t, err)
+		//when
 		err = ensureFileExecutable(pathToFile, zap.NewNop().Sugar())
 		require.NoError(t, err)
+		//then
 		stat, err := os.Stat(pathToFile)
 		require.NoError(t, err)
 		require.Equal(t, os.FileMode(0777), stat.Mode())
 
 	})
 	t.Run("should return error when file does not exist", func(t *testing.T) {
+		//given
 		pathToFile := "not-existing"
+		//when
 		err := ensureFileExecutable(pathToFile, zap.NewNop().Sugar())
+		//then
 		require.Error(t, err)
 	})
 	t.Run("should return error when path is empty", func(t *testing.T) {
+		//given
 		pathToFile := ""
+		//when
 		err := ensureFileExecutable(pathToFile, zap.NewNop().Sugar())
+		//then
 		require.Error(t, err)
 	})
 }

--- a/pkg/reconciler/instances/istio/bootstrap_test.go
+++ b/pkg/reconciler/instances/istio/bootstrap_test.go
@@ -122,7 +122,7 @@ func TestParsePaths(t *testing.T) {
 	})
 }
 
-func TestChmodExecutbale(t *testing.T) {
+func TestChmodExecutable(t *testing.T) {
 	t.Run("chmod to 0777", func(t *testing.T) {
 		pathToFile := "tmp/dat1"
 		t.Cleanup(func() {
@@ -139,12 +139,12 @@ func TestChmodExecutbale(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, os.FileMode(0777), stat.Mode())
 	})
-	t.Run("chmodExecutable should return an error if file is not existing", func(t *testing.T) {
+	t.Run("should return an error when file does not exist", func(t *testing.T) {
 		pathToFile := "not-existing"
 		err := chmodExecutbale(pathToFile, zap.NewNop().Sugar())
 		require.Error(t, err)
 	})
-	t.Run("chmodExecutable should return an error if pathToFile is empty", func(t *testing.T) {
+	t.Run("should return an error when path to file is empty", func(t *testing.T) {
 		pathToFile := ""
 		err := chmodExecutbale(pathToFile, zap.NewNop().Sugar())
 		require.Error(t, err)
@@ -152,7 +152,7 @@ func TestChmodExecutbale(t *testing.T) {
 }
 
 func TestValidatePath(t *testing.T) {
-	t.Run("validatePath should return nil and change mode of file to 0777", func(t *testing.T) {
+	t.Run("should return nil and change mode of file to 0777 when it had 0000", func(t *testing.T) {
 		pathToFile := "tmp/dat1"
 		t.Cleanup(func() {
 			err := os.RemoveAll("tmp")
@@ -169,12 +169,12 @@ func TestValidatePath(t *testing.T) {
 		require.Equal(t, os.FileMode(0777), stat.Mode())
 
 	})
-	t.Run("validatePath should return error if file is not existing", func(t *testing.T) {
+	t.Run("should return error when file does not exist", func(t *testing.T) {
 		pathToFile := "not-existing"
 		err := validatePath(pathToFile, zap.NewNop().Sugar())
 		require.Error(t, err)
 	})
-	t.Run("validatePath should return error if path is empty", func(t *testing.T) {
+	t.Run("should return error when path is empty", func(t *testing.T) {
 		pathToFile := ""
 		err := validatePath(pathToFile, zap.NewNop().Sugar())
 		require.Error(t, err)

--- a/pkg/reconciler/instances/istio/bootstrap_test.go
+++ b/pkg/reconciler/instances/istio/bootstrap_test.go
@@ -124,17 +124,20 @@ func TestParsePaths(t *testing.T) {
 
 func TestChmodExecutbale(t *testing.T) {
 	t.Run("chmod to 0777", func(t *testing.T) {
-		pathToFile := "dat1"
+		pathToFile := "tmp/dat1"
+		t.Cleanup(func() {
+			err := os.RemoveAll("tmp")
+			require.NoError(t, err)
+		})
+		require.NoError(t, os.MkdirAll("tmp", 0777))
 		d1 := []byte("hello\nworld\n")
-		err := os.WriteFile(pathToFile, d1, 0111)
+		err := os.WriteFile(pathToFile, d1, 0000)
 		require.NoError(t, err)
 		err = chmodExecutbale(pathToFile, zap.NewNop().Sugar())
 		require.NoError(t, err)
 		stat, err := os.Stat(pathToFile)
 		require.NoError(t, err)
 		require.Equal(t, os.FileMode(0777), stat.Mode())
-		err = os.RemoveAll(pathToFile)
-		require.NoError(t, err)
 	})
 	t.Run("chmodExecutable should return an error if file is not existing", func(t *testing.T) {
 		pathToFile := "not-existing"
@@ -150,17 +153,21 @@ func TestChmodExecutbale(t *testing.T) {
 
 func TestValidatePath(t *testing.T) {
 	t.Run("validatePath should return nil and change mode of file to 0777", func(t *testing.T) {
-		pathToFile := "dat1"
+		pathToFile := "tmp/dat1"
+		t.Cleanup(func() {
+			err := os.RemoveAll("tmp")
+			require.NoError(t, err)
+		})
+		require.NoError(t, os.MkdirAll("tmp", 0777))
 		d1 := []byte("hello\nworld\n")
-		err := os.WriteFile(pathToFile, d1, 0111)
+		err := os.WriteFile(pathToFile, d1, 0000)
 		require.NoError(t, err)
 		err = validatePath(pathToFile, zap.NewNop().Sugar())
 		require.NoError(t, err)
 		stat, err := os.Stat(pathToFile)
 		require.NoError(t, err)
 		require.Equal(t, os.FileMode(0777), stat.Mode())
-		err = os.RemoveAll(pathToFile)
-		require.NoError(t, err)
+
 	})
 	t.Run("validatePath should return error if file is not existing", func(t *testing.T) {
 		pathToFile := "not-existing"

--- a/pkg/reconciler/instances/rma/integration_action.go
+++ b/pkg/reconciler/instances/rma/integration_action.go
@@ -37,7 +37,6 @@ type IntegrationAction struct {
 	client       IntegrationClient
 	mux          sync.Mutex
 	archives     map[string][]byte
-	pwds         map[string]string
 	chartVerExpr *regexp.Regexp
 }
 
@@ -49,7 +48,6 @@ func NewIntegrationAction(name string, client IntegrationClient) *IntegrationAct
 			Timeout: 20 * time.Second,
 		},
 		archives:     make(map[string][]byte),
-		pwds:         make(map[string]string),
 		chartVerExpr: regexp.MustCompile(fmt.Sprintf("%s-([a-zA-Z0-9-.]+)\\.tgz$", RmiChartName)),
 	}
 }
@@ -119,7 +117,7 @@ func (a *IntegrationAction) Run(context *service.ActionContext) error {
 		return a.upgrade(context, cfg, chartURL, releaseName, namespace, skipHelmUpgrade)
 	case model.OperationTypeDelete:
 		if err == nil {
-			return a.delete(context, cfg, releaseName)
+			return a.delete(cfg, releaseName)
 		}
 	}
 
@@ -150,13 +148,12 @@ func (a *IntegrationAction) install(context *service.ActionContext, cfg *action.
 	}
 
 	setAuthCredentialOverrides(context.Task.Configuration, username, password)
-	a.setPassword(username, password)
 	return nil
 }
 
 func (a *IntegrationAction) upgrade(context *service.ActionContext, cfg *action.Configuration, chartURL, releaseName, namespace string, skipHelmUpgrade bool) error {
 	username := context.Task.Metadata.InstanceID
-	password, err := a.fetchPassword(context.Context, username, releaseName, namespace)
+	password, err := a.fetchPassword(context.Context, releaseName, namespace)
 	if err != nil {
 		return errors.WithMessage(err, "failed to fetch auth credentials from secret")
 	}
@@ -188,7 +185,7 @@ func (a *IntegrationAction) upgrade(context *service.ActionContext, cfg *action.
 	return nil
 }
 
-func (a *IntegrationAction) delete(context *service.ActionContext, cfg *action.Configuration, releaseName string) error {
+func (a *IntegrationAction) delete(cfg *action.Configuration, releaseName string) error {
 	uninstallAction := action.NewUninstall(cfg)
 	uninstallAction.Timeout = 5 * time.Minute
 
@@ -197,7 +194,6 @@ func (a *IntegrationAction) delete(context *service.ActionContext, cfg *action.C
 		return errors.WithMessagef(err, "helm delete %s-%s failed", RmiChartName, releaseName)
 	}
 
-	a.deletePassword(context.Task.Metadata.InstanceID)
 	return nil
 }
 
@@ -236,30 +232,23 @@ func (a *IntegrationAction) fetchChart(ctx context.Context, chartURL string) (*c
 	return chart, nil
 }
 
-func (a *IntegrationAction) fetchPassword(ctx context.Context, username, release, namespace string) (string, error) {
-	a.mux.Lock()
-	defer a.mux.Unlock()
-	password := a.pwds[username]
-
-	if password == "" {
-		client, err := a.client.KubernetesClientSet()
-		if err != nil {
-			return "", err
-		}
-		secret, err := client.CoreV1().Secrets(namespace).Get(ctx, fmt.Sprintf("vmuser-%s-%s", RmiChartName, release), metav1.GetOptions{})
-		if err != nil {
-			return "", err
-		}
-		if secret.Data == nil {
-			return "", errors.New("secret data is empty")
-		}
-		passwordData := secret.Data["password"]
-		if len(passwordData) == 0 {
-			return "", errors.New("missing/empty auth credentials")
-		}
-		password = string(passwordData)
-		a.pwds[username] = password
+func (a *IntegrationAction) fetchPassword(ctx context.Context, release, namespace string) (string, error) {
+	client, err := a.client.KubernetesClientSet()
+	if err != nil {
+		return "", err
 	}
+	secret, err := client.CoreV1().Secrets(namespace).Get(ctx, fmt.Sprintf("vmuser-%s-%s", RmiChartName, release), metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	if secret.Data == nil {
+		return "", errors.New("secret data is empty")
+	}
+	passwordData := secret.Data["password"]
+	if len(passwordData) == 0 {
+		return "", errors.New("missing/empty auth credentials")
+	}
+	password := string(passwordData)
 
 	return password, nil
 }
@@ -276,18 +265,6 @@ func generatePassword(n int) (string, error) {
 	}
 
 	return string(ret), nil
-}
-
-func (a *IntegrationAction) setPassword(username, password string) {
-	a.mux.Lock()
-	defer a.mux.Unlock()
-	a.pwds[username] = password
-}
-
-func (a *IntegrationAction) deletePassword(username string) {
-	a.mux.Lock()
-	defer a.mux.Unlock()
-	delete(a.pwds, username)
 }
 
 func (a *IntegrationAction) getChartVersionFromURL(chartURL string) string {


### PR DESCRIPTION
### Changes proposed

- Use `;` to separate paths instead of `:`. Since in Windows `:` can be used inside paths, i.e.  `C:\Users\`, which lead to fail the Kyma CLI on Windows Systems. Without this change Kyma CLI is not able to work on Windows distributions
- If `istioctl` is non executable, try to set tit to executable once and if it fails, let the component fail, instead of instant failure
- Propagate logger to have better debugging

### Links
See: https://github.com/kyma-incubator/reconciler/issues/962 