### PR TITLE
Safe cleanup of service catalog instances

### DIFF
--- a/pkg/reconciler/instances/scmigration/btp_operator_migration.go
+++ b/pkg/reconciler/instances/scmigration/btp_operator_migration.go
@@ -15,8 +15,10 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -29,10 +31,16 @@ import (
 // https://github.com/SAP/sap-btp-service-operator-migration/blob/v0.1.2/migrate/migrator.go
 
 const (
-	migratedLabel    = "migrated"
-	serviceInstances = "serviceinstances"
-	serviceBindings  = "servicebindings"
+	migratedLabel         = "migrated"
+	serviceInstances      = "serviceinstances"
+	serviceBindings       = "servicebindings"
+	clusterserviceclasses = "clusterserviceclasses"
 )
+
+type classes struct {
+	byRef  map[string]v1beta1.ClusterServiceClass
+	byName map[string]v1beta1.ClusterServiceClass
+}
 
 type serviceInstancePair struct {
 	svcatInstance *v1beta1.ServiceInstance
@@ -154,20 +162,23 @@ func (m *migrator) migrateBTPOperator() error {
 	ctx := m.ac.Context
 	svcatInstances := v1beta1.ServiceInstanceList{}
 	err = m.SvcatRestClient.Get().Namespace("").Resource(serviceInstances).Do(ctx).Into(&svcatInstances)
-	if err != nil && !errors.IsNotFound(err) {
+	if err != nil && !(errors.IsNotFound(err) || meta.IsNoMatchError(err)) {
 		return err
 	}
 	m.ac.Logger.Infof("Fetched %v svcat instances from cluster", len(svcatInstances.Items))
 
 	svcatBindings := v1beta1.ServiceBindingList{}
 	err = m.SvcatRestClient.Get().Namespace("").Resource(serviceBindings).Do(ctx).Into(&svcatBindings)
-	if err != nil && !errors.IsNotFound(err) {
+	if err != nil && !(errors.IsNotFound(err) || meta.IsNoMatchError(err)) {
 		return err
 	}
 	m.ac.Logger.Infof("Fetched %v svcat bindings from cluster", len(svcatBindings.Items))
 
 	m.ac.Logger.Infof("Preparing resources")
-	instancesToMigrate := m.getInstancesToMigrate(smInstances, svcatInstances)
+	instancesToMigrate, err := m.getInstancesToMigrate(smInstances, svcatInstances)
+	if err != nil {
+		return err
+	}
 	bindingsToMigrate := m.getBindingsToMigrate(smBindings, svcatBindings)
 	if len(instancesToMigrate) == 0 && len(bindingsToMigrate) == 0 {
 		m.ac.Logger.Infof("no svcat instances or bindings found for migration")
@@ -201,8 +212,57 @@ func (m *migrator) migrateBTPOperator() error {
 	return nil
 }
 
-func (m *migrator) getInstancesToMigrate(smInstances *types.ServiceInstances, svcatInstances v1beta1.ServiceInstanceList) []serviceInstancePair {
+func (m *migrator) fetchClasses() (classes, error) {
+	ctx := m.ac.Context
+	list := v1beta1.ClusterServiceClassList{}
+	err := m.SvcatRestClient.Get().Namespace("").Resource(clusterserviceclasses).Do(ctx).Into(&list)
+	classes := classes{}
+	if meta.IsNoMatchError(err) || errors.IsNotFound(err) {
+		return classes, nil
+	}
+	if err != nil {
+		return classes, err
+	}
+	m.ac.Logger.Infof("Fetched %v svcat cluster classes from cluster", len(list.Items))
+	classes.byName = make(map[string]v1beta1.ClusterServiceClass)
+	classes.byRef = make(map[string]v1beta1.ClusterServiceClass)
+	for _, c := range list.Items {
+		classes.byRef[c.Name] = c
+		classes.byName[c.Spec.ExternalName] = c
+	}
+	return classes, nil
+}
+
+func (b classes) hasSMBroker(instance v1beta1.ServiceInstance) bool {
+	if ref := instance.Spec.ClusterServiceClassRef; ref != nil {
+		if csc, found := b.byRef[ref.Name]; found {
+			if strings.HasPrefix(csc.Spec.ClusterServiceBrokerName, "sm-") {
+				return true
+			}
+		}
+	}
+	if name := instance.Spec.ClusterServiceClassName; name != "" {
+		if csc, found := b.byName[name]; found {
+			if strings.HasPrefix(csc.Spec.ClusterServiceBrokerName, "sm-") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isReady(instance v1beta1.ServiceInstance) bool {
+	return v1beta1.ServiceInstanceConditionType(instance.Status.LastConditionState) == v1beta1.ServiceInstanceConditionReady
+}
+
+func (m *migrator) getInstancesToMigrate(smInstances *types.ServiceInstances, svcatInstances v1beta1.ServiceInstanceList) ([]serviceInstancePair, error) {
+	classes, err := m.fetchClasses()
+	if err != nil {
+		return nil, err
+	}
+
 	validInstances := make([]serviceInstancePair, 0)
+	var errs []error
 	for _, svcat := range svcatInstances.Items {
 		var smInstance *types.ServiceInstance
 		for i, instance := range smInstances.ServiceInstances {
@@ -212,8 +272,12 @@ func (m *migrator) getInstancesToMigrate(smInstances *types.ServiceInstances, sv
 			}
 		}
 		if smInstance == nil {
-			m.ac.Logger.Infof("svcat instance name '%s' id '%s' (%s) not found in SM, skipping it...", svcat.Name, svcat.Spec.ExternalID, svcat.Name)
-			continue
+			if isReady(svcat) && classes.hasSMBroker(svcat) {
+				err := fmt.Errorf("svcat instance name '%s/%s' id '%s' (%s) not found in SM but expected", svcat.Namespace, svcat.Name, svcat.Spec.ExternalID, svcat.Name)
+				errs = append(errs, err)
+			} else {
+				m.ac.Logger.Info("svcat instance name '%s/%s' id '%s' (%s) not found in SM, skipping", svcat.Namespace, svcat.Name, svcat.Spec.ExternalID, svcat.Name)
+			}
 		}
 		svcInstance := svcat
 		validInstances = append(validInstances, serviceInstancePair{
@@ -221,8 +285,7 @@ func (m *migrator) getInstancesToMigrate(smInstances *types.ServiceInstances, sv
 			smInstance:    smInstance,
 		})
 	}
-
-	return validInstances
+	return validInstances, kerrors.NewAggregate(errs)
 }
 
 func (m *migrator) getBindingsToMigrate(smBindings *types.ServiceBindings, svcatBindings v1beta1.ServiceBindingList) []serviceBindingPair {
@@ -406,6 +469,10 @@ func (m *migrator) getInstanceStruct(pair serviceInstancePair) *v1alpha1.Service
 	if err != nil {
 		m.ac.Logger.Infof("failed to parse user info for instance %s: %v", pair.svcatInstance.Name, err.Error())
 	}
+	svcatInstanceAnnotation, err := json.Marshal(pair.svcatInstance)
+	if err != nil {
+		m.ac.Logger.Infof("failed to marshal svcat instance %s: %v", pair.svcatInstance.Name, err.Error())
+	}
 
 	return &v1alpha1.ServiceInstance{
 		TypeMeta: metav1.TypeMeta{
@@ -420,7 +487,9 @@ func (m *migrator) getInstanceStruct(pair serviceInstancePair) *v1alpha1.Service
 			},
 			Annotations: map[string]string{
 				"original_creation_timestamp": pair.svcatInstance.CreationTimestamp.String(),
-				"original_user_info":          string(userInfo)},
+				"original_user_info":          string(userInfo),
+				"original_instance":           string(svcatInstanceAnnotation),
+			},
 		},
 		Spec: v1alpha1.ServiceInstanceSpec{
 			ServicePlanName:     plan.Name,
@@ -447,6 +516,10 @@ func (m *migrator) getBindingStruct(pair serviceBindingPair) *v1alpha1.ServiceBi
 	if err != nil {
 		m.ac.Logger.Infof("failed to parse user info for binding %s. Error: %v", pair.svcatBinding.Name, err.Error())
 	}
+	svcatBindingAnnotation, err := json.Marshal(pair.svcatBinding)
+	if err != nil {
+		m.ac.Logger.Infof("failed to marshal svcat binding %s: %v", pair.svcatBinding.Name, err.Error())
+	}
 
 	return &v1alpha1.ServiceBinding{
 		TypeMeta: metav1.TypeMeta{
@@ -461,7 +534,9 @@ func (m *migrator) getBindingStruct(pair serviceBindingPair) *v1alpha1.ServiceBi
 			},
 			Annotations: map[string]string{
 				"original_creation_timestamp": pair.svcatBinding.CreationTimestamp.String(),
-				"original_user_info":          string(userInfo)},
+				"original_user_info":          string(userInfo),
+				"original_binding":            string(svcatBindingAnnotation),
+			},
 		},
 		Spec: v1alpha1.ServiceBindingSpec{
 			ServiceInstanceName: pair.svcatBinding.Spec.InstanceRef.Name,
@@ -497,9 +572,8 @@ func (m *migrator) deleteSvcatResource(resourceName string, resourceNamespace st
 		return err
 	}
 
-	//fmt.Println(fmt.Sprintf("deleting svcat resource type '%s' named '%s' in namespace '%s'", resourceType, resourceName, resourceNamespace))
-	err = m.SvcatRestClient.Delete().Name(resourceName).Namespace(resourceNamespace).Resource(resourceType).Do(m.ac.Context).Error()
-	return err
+	m.ac.Logger.Infof("deleting svcat resource type '%s' named '%s' in namespace '%s'", resourceType, resourceName, resourceNamespace)
+	return m.SvcatRestClient.Delete().Name(resourceName).Namespace(resourceNamespace).Resource(resourceType).Do(m.ac.Context).Error()
 }
 
 func (m *migrator) getMigrateBindingRequestBody(k8sName string, secret *corev1.Secret) (string, error) {

--- a/pkg/reconciler/instances/scmigration/sc_removal.go
+++ b/pkg/reconciler/instances/scmigration/sc_removal.go
@@ -156,6 +156,16 @@ func (c *scremoval) prepareForRemoval(ac *service.ActionContext) error {
 	gvkList := []schema.GroupVersionKind{
 		{
 			Group:   "servicecatalog.k8s.io",
+			Kind:    "ServiceBindingList",
+			Version: "v1beta1",
+		},
+		{
+			Group:   "servicecatalog.k8s.io",
+			Kind:    "ServiceInstanceList",
+			Version: "v1beta1",
+		},
+		{
+			Group:   "servicecatalog.k8s.io",
 			Kind:    "ServiceBrokerList",
 			Version: "v1beta1",
 		},
@@ -258,6 +268,16 @@ func (c *scremoval) removeResources(ac *service.ActionContext) error {
 			Kind:    "UsageKind",
 			Group:   "servicecatalog.kyma-project.io",
 			Version: "v1alpha1",
+		},
+		{
+			Kind:    "ServiceBinding",
+			Group:   "servicecatalog.k8s.io",
+			Version: "v1beta1",
+		},
+		{
+			Kind:    "ServiceInstance",
+			Group:   "servicecatalog.k8s.io",
+			Version: "v1beta1",
 		},
 		{
 			Kind:    "ServiceBroker",


### PR DESCRIPTION
Followup to https://github.com/kyma-incubator/reconciler/pull/875

As part of service catalog migration and cleanup, it's desired to actually delete the instances and bindings but this PR introduces safer deletion algorithm
* check if service manager knows about the instance
  * if it does - instance must be migrated
  * if it doesn't - halt and error if the instance is ready and has a broker with prefix `sm-`