### PR TITLE
Exclude pods in Pending phase from Istio Proxy Reset

### DIFF
--- a/pkg/reconciler/instances/istio/reset/data/gatherer.go
+++ b/pkg/reconciler/instances/istio/reset/data/gatherer.go
@@ -59,14 +59,26 @@ func (i *DefaultGatherer) GetPodsWithDifferentImage(inputPodsList v1.PodList, im
 		for _, container := range pod.Spec.Containers {
 			containsPrefix := strings.Contains(container.Image, image.Prefix)
 			hasSuffix := strings.HasSuffix(container.Image, image.Version)
-			isTerminating := pod.Status.Phase == "Terminating"
-			isPending := pod.Status.Phase == "Pending"
+			ready := isPodReady(pod)
 
-			if containsPrefix && !hasSuffix && !isTerminating && !isPending {
+			if containsPrefix && !hasSuffix && ready {
 				outputPodsList.Items = append(outputPodsList.Items, *pod.DeepCopy())
 			}
 		}
 	}
 
 	return
+}
+
+func isPodReady(pod v1.Pod) bool {
+	if pod.Status.Phase != v1.PodRunning {
+		return false
+	}
+	for _, condition := range pod.Status.Conditions {
+		if condition.Status != v1.ConditionTrue {
+			return false
+		}
+	}
+	//deletion timestamp determines whether pod is terminating or running (nil == running)
+	return pod.ObjectMeta.DeletionTimestamp == nil
 }

--- a/pkg/reconciler/instances/istio/reset/data/gatherer.go
+++ b/pkg/reconciler/instances/istio/reset/data/gatherer.go
@@ -59,9 +59,9 @@ func (i *DefaultGatherer) GetPodsWithDifferentImage(inputPodsList v1.PodList, im
 		for _, container := range pod.Spec.Containers {
 			containsPrefix := strings.Contains(container.Image, image.Prefix)
 			hasSuffix := strings.HasSuffix(container.Image, image.Version)
-			ready := isPodReady(pod)
+			readiness := isPodReady(pod)
 
-			if containsPrefix && !hasSuffix && ready {
+			if containsPrefix && !hasSuffix && readiness {
 				outputPodsList.Items = append(outputPodsList.Items, *pod.DeepCopy())
 			}
 		}
@@ -70,7 +70,9 @@ func (i *DefaultGatherer) GetPodsWithDifferentImage(inputPodsList v1.PodList, im
 	return
 }
 
+// isPodReady checks if the pod is Ready, returns true if the Pod is in the Running state and not Pending or Terminating.
 func isPodReady(pod v1.Pod) bool {
+
 	if pod.Status.Phase != v1.PodRunning {
 		return false
 	}
@@ -79,6 +81,6 @@ func isPodReady(pod v1.Pod) bool {
 			return false
 		}
 	}
-	//deletion timestamp determines whether pod is terminating or running (nil == running)
+
 	return pod.ObjectMeta.DeletionTimestamp == nil
 }

--- a/pkg/reconciler/instances/istio/reset/data/gatherer.go
+++ b/pkg/reconciler/instances/istio/reset/data/gatherer.go
@@ -60,8 +60,9 @@ func (i *DefaultGatherer) GetPodsWithDifferentImage(inputPodsList v1.PodList, im
 			containsPrefix := strings.Contains(container.Image, image.Prefix)
 			hasSuffix := strings.HasSuffix(container.Image, image.Version)
 			isTerminating := pod.Status.Phase == "Terminating"
+			isPending := pod.Status.Phase == "Pending"
 
-			if containsPrefix && !hasSuffix && !isTerminating {
+			if containsPrefix && !hasSuffix && !isTerminating && !isPending {
 				outputPodsList.Items = append(outputPodsList.Items, *pod.DeepCopy())
 			}
 		}

--- a/pkg/reconciler/instances/istio/reset/data/gatherer_test.go
+++ b/pkg/reconciler/instances/istio/reset/data/gatherer_test.go
@@ -50,8 +50,10 @@ func Test_Gatherer_GetPodsWithDifferentImage(t *testing.T) {
 	}
 	podWithExpectedImage := fixPodWith("application", "kyma", "istio/proxyv2:1.10.1", "Running")
 	podWithExpectedImageTerminating := fixPodWith("istio", "custom", "istio/proxyv2:1.10.2", "Terminating")
+	podWithExpectedImagePending := fixPodWith("istio", "custom", "istio/proxyv2:1.10.2", "Pending")
 	podWithDifferentImageSuffix := fixPodWith("istio", "custom", "istio/proxyv2:1.10.2", "Running")
 	podWithDifferentImageSuffixTerminating := fixPodWith("application", "kyma", "istio/proxyv2:1.10.2", "Terminating")
+	podWithDifferentImageSuffixPending := fixPodWith("application", "kyma", "istio/proxyv2:1.10.2", "Pending")
 	podWithDifferentImagePrefix := fixPodWith("application", "kyma", "istio/weirdimage:1.10.2", "Running")
 
 	t.Run("should not get any pods from an empty list", func(t *testing.T) {
@@ -72,8 +74,10 @@ func Test_Gatherer_GetPodsWithDifferentImage(t *testing.T) {
 		pods.Items = []v1.Pod{
 			*podWithExpectedImage,
 			*podWithExpectedImageTerminating,
+			*podWithExpectedImagePending,
 			*podWithDifferentImageSuffix,
 			*podWithDifferentImageSuffixTerminating,
+			*podWithDifferentImageSuffixPending,
 			*podWithDifferentImagePrefix,
 		}
 		gatherer := DefaultGatherer{}

--- a/pkg/reconciler/instances/istio/reset/data/gatherer_test.go
+++ b/pkg/reconciler/instances/istio/reset/data/gatherer_test.go
@@ -71,6 +71,7 @@ func Test_Gatherer_GetPodsWithDifferentImage(t *testing.T) {
 	t.Run("should get one pod from the list", func(t *testing.T) {
 		// given
 		var pods v1.PodList
+		var expected v1.PodList
 		pods.Items = []v1.Pod{
 			*podWithExpectedImage,
 			*podWithExpectedImageTerminating,
@@ -80,12 +81,16 @@ func Test_Gatherer_GetPodsWithDifferentImage(t *testing.T) {
 			*podWithDifferentImageSuffixPending,
 			*podWithDifferentImagePrefix,
 		}
+		expected.Items = []v1.Pod{
+			*podWithDifferentImageSuffix,
+		}
 		gatherer := DefaultGatherer{}
 
 		// when
 		podsWithDifferentImage := gatherer.GetPodsWithDifferentImage(pods, image)
 
 		// then
+		require.Equal(t, podsWithDifferentImage.Items, expected.Items)
 		require.NotEmpty(t, podsWithDifferentImage.Items)
 		require.Len(t, podsWithDifferentImage.Items, 1)
 	})


### PR DESCRIPTION
This fixes an issue, when customer pods with sidecar fail to reconcile, whenever they are stuck in a constant pending phase.
Added the function for checking the pod's state.