### PR TITLE
Log applied IstioOperator yaml in case of error

### DIFF
--- a/internal/persistency/registry.go
+++ b/internal/persistency/registry.go
@@ -113,7 +113,7 @@ func (or *Registry) initReconciliationRepository() (reconciliation.Repository, e
 }
 
 func (or *Registry) initOccupancyRepository() (occupancy.Repository, error) {
-	if !features.WorkerpoolOccupancyTrackingEnabled() {
+	if !features.Enabled(features.WorkerpoolOccupancyTracking) {
 		return occupancy.CreateMockRepository(), nil
 	}
 	occupancyRepo, err := occupancy.NewPersistentOccupancyRepository(or.connection, or.debug)

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -5,20 +5,27 @@ import (
 	"strings"
 )
 
-const processingDurationMetricEnvVar = "PROCESSING_DURATION_METRICS_ENABLED"
-const workerpoolOccupancyTrackingEnvVar = "WORKERPOOL_OCCUPANCY_TRACKING_ENABLED"
-const logIstioOperator = "LOG_ISTIO_OPERATOR"
+type Feature int
 
-func ProcessingDurationMetricsEnabled() bool {
-	return checkEnvVar(processingDurationMetricEnvVar)
+const (
+	ProcessingDurationMetric Feature = iota + 1
+	WorkerpoolOccupancyTracking
+	LogIstioOperator
+)
+
+//define the mapping between feature name and env var name
+var featureEnVarMap = map[Feature]string{
+	ProcessingDurationMetric:    "PROCESSING_DURATION_METRICS_ENABLED",
+	WorkerpoolOccupancyTracking: "WORKERPOOL_OCCUPANCY_TRACKING_ENABLED",
+	LogIstioOperator:            "LOG_ISTIO_OPERATOR",
 }
 
-func WorkerpoolOccupancyTrackingEnabled() bool {
-	return checkEnvVar(workerpoolOccupancyTrackingEnvVar)
+func Enabled(feature Feature) bool {
+	return checkEnvVar(envVar(feature))
 }
 
-func LogIstioOperator() bool {
-	return checkEnvVar(logIstioOperator)
+func envVar(feature Feature) string {
+	return featureEnVarMap[feature]
 }
 
 func checkEnvVar(envVar string) bool {

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -7,6 +7,7 @@ import (
 
 const processingDurationMetricEnvVar = "PROCESSING_DURATION_METRICS_ENABLED"
 const workerpoolOccupancyTrackingEnvVar = "WORKERPOOL_OCCUPANCY_TRACKING_ENABLED"
+const logIstioOperator = "LOG_ISTIO_OPERATOR"
 
 func ProcessingDurationMetricsEnabled() bool {
 	return checkEnvVar(processingDurationMetricEnvVar)
@@ -14,6 +15,10 @@ func ProcessingDurationMetricsEnabled() bool {
 
 func WorkerpoolOccupancyTrackingEnabled() bool {
 	return checkEnvVar(workerpoolOccupancyTrackingEnvVar)
+}
+
+func LogIstioOperator() bool {
+	return checkEnvVar(logIstioOperator)
 }
 
 func checkEnvVar(envVar string) bool {

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -10,35 +10,34 @@ func TestFeatures(t *testing.T) {
 
 	type testCases struct {
 		description    string
-		funcToTest     func() bool
-		envVar         string
+		feature        Feature
 		envVarValue    string
 		expectedResult bool
 	}
 
 	for _, testCase := range []testCases{
-		{description: "Workerpool Occupancy set to 1", funcToTest: WorkerpoolOccupancyTrackingEnabled, envVar: workerpoolOccupancyTrackingEnvVar, envVarValue: "1", expectedResult: true},
-		{description: "Workerpool Occupancy set to lowercase true", funcToTest: WorkerpoolOccupancyTrackingEnabled, envVar: workerpoolOccupancyTrackingEnvVar, envVarValue: "true", expectedResult: true},
-		{description: "Workerpool Occupancy set to TrUe; not lowercase", funcToTest: WorkerpoolOccupancyTrackingEnabled, envVar: workerpoolOccupancyTrackingEnvVar, envVarValue: "TrUe", expectedResult: true},
-		{description: "Workerpool Occupancy set to 0", funcToTest: WorkerpoolOccupancyTrackingEnabled, envVar: workerpoolOccupancyTrackingEnvVar, envVarValue: "0", expectedResult: false},
-		{description: "Workerpool Occupancy not set", funcToTest: WorkerpoolOccupancyTrackingEnabled, envVar: workerpoolOccupancyTrackingEnvVar, envVarValue: "", expectedResult: false},
-		{description: "Processing Duration Metric set to 1", funcToTest: ProcessingDurationMetricsEnabled, envVar: processingDurationMetricEnvVar, envVarValue: "1", expectedResult: true},
-		{description: "Processing Duration Metric set to lowercase true", funcToTest: ProcessingDurationMetricsEnabled, envVar: processingDurationMetricEnvVar, envVarValue: "true", expectedResult: true},
-		{description: "Processing Duration Metric set to TrUe; not lowercase", funcToTest: ProcessingDurationMetricsEnabled, envVar: processingDurationMetricEnvVar, envVarValue: "TrUe", expectedResult: true},
-		{description: "Processing Duration Metric set to 0", funcToTest: ProcessingDurationMetricsEnabled, envVar: processingDurationMetricEnvVar, envVarValue: "0", expectedResult: false},
-		{description: "Processing Duration Metric not set", funcToTest: ProcessingDurationMetricsEnabled, envVar: processingDurationMetricEnvVar, envVarValue: "", expectedResult: false},
+		{description: "Workerpool Occupancy set to 1", feature: WorkerpoolOccupancyTracking, envVarValue: "1", expectedResult: true},
+		{description: "Workerpool Occupancy set to lowercase true", feature: WorkerpoolOccupancyTracking, envVarValue: "true", expectedResult: true},
+		{description: "Workerpool Occupancy set to TrUe; not lowercase", feature: WorkerpoolOccupancyTracking, envVarValue: "TrUe", expectedResult: true},
+		{description: "Workerpool Occupancy set to 0", feature: WorkerpoolOccupancyTracking, envVarValue: "0", expectedResult: false},
+		{description: "Workerpool Occupancy not set", feature: WorkerpoolOccupancyTracking, envVarValue: "", expectedResult: false},
+		{description: "Processing Duration Metric set to 1", feature: WorkerpoolOccupancyTracking, envVarValue: "1", expectedResult: true},
+		{description: "Processing Duration Metric set to lowercase true", feature: WorkerpoolOccupancyTracking, envVarValue: "true", expectedResult: true},
+		{description: "Processing Duration Metric set to TrUe; not lowercase", feature: WorkerpoolOccupancyTracking, envVarValue: "TrUe", expectedResult: true},
+		{description: "Processing Duration Metric set to 0", feature: WorkerpoolOccupancyTracking, envVarValue: "0", expectedResult: false},
+		{description: "Processing Duration Metric not set", feature: WorkerpoolOccupancyTracking, envVarValue: "", expectedResult: false},
 	} {
 		test := testCase
 		t.Run(test.description, func(t *testing.T) {
 			if test.envVarValue != "" {
-				err := os.Setenv(test.envVar, test.envVarValue)
+				err := os.Setenv(envVar(test.feature), test.envVarValue)
 				require.NoError(t, err)
 			}
 
-			actualResult := test.funcToTest()
+			actualResult := Enabled(test.feature)
 			require.Equal(t, test.expectedResult, actualResult)
 
-			err := os.Unsetenv(test.envVar)
+			err := os.Unsetenv(envVar(test.feature))
 			require.NoError(t, err)
 		})
 	}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -11,7 +11,7 @@ import (
 )
 
 func RegisterProcessingDuration(reconciliations reconciliation.Repository, logger *zap.SugaredLogger) {
-	if features.ProcessingDurationMetricsEnabled() {
+	if features.Enabled(features.ProcessingDurationMetric) {
 		processingDurationCollector := NewProcessingDurationCollector(reconciliations, logger)
 		prometheus.MustRegister(processingDurationCollector)
 	}
@@ -24,7 +24,7 @@ func RegisterWaitingAndNotReadyReconciliations(inventory cluster.Inventory, logg
 }
 
 func RegisterOccupancy(occupancyRepo occupancy.Repository, reconcilers map[string]config.ComponentReconciler, logger *zap.SugaredLogger) {
-	if features.WorkerpoolOccupancyTrackingEnabled() {
+	if features.Enabled(features.WorkerpoolOccupancyTracking) {
 		prometheus.MustRegister(NewWorkerPoolOccupancyCollector(occupancyRepo, reconcilers, logger))
 	}
 }

--- a/pkg/reconciler/instances/istio/istioctl/commander.go
+++ b/pkg/reconciler/instances/istio/istioctl/commander.go
@@ -2,6 +2,8 @@ package istioctl
 
 import (
 	"bufio"
+	"github.com/kyma-incubator/reconciler/pkg/features"
+	"github.com/pkg/errors"
 	"io"
 	"os/exec"
 	"sync"
@@ -85,7 +87,11 @@ func (c *DefaultCommander) Install(istioOperator, kubeconfig string, logger *zap
 
 	cmd := execCommand(c.istioctl.path, "apply", "-f", istioOperatorPath, "--kubeconfig", kubeconfigPath, "--skip-confirmation")
 
-	return c.execute(cmd, logger)
+	err = c.execute(cmd, logger)
+	if features.LogIstioOperator() {
+		return errors.Wrapf(err, "rendered IstioOperator yaml was: %s ", istioOperator)
+	}
+	return err
 }
 
 func (c *DefaultCommander) Upgrade(istioOperator, kubeconfig string, logger *zap.SugaredLogger) error {

--- a/pkg/reconciler/instances/istio/istioctl/commander.go
+++ b/pkg/reconciler/instances/istio/istioctl/commander.go
@@ -88,7 +88,7 @@ func (c *DefaultCommander) Install(istioOperator, kubeconfig string, logger *zap
 	cmd := execCommand(c.istioctl.path, "apply", "-f", istioOperatorPath, "--kubeconfig", kubeconfigPath, "--skip-confirmation")
 
 	err = c.execute(cmd, logger)
-	if features.LogIstioOperator() {
+	if err != nil && features.Enabled(features.LogIstioOperator) {
 		return errors.Wrapf(err, "rendered IstioOperator yaml was: %s ", istioOperator)
 	}
 	return err

--- a/pkg/scheduler/service/run.go
+++ b/pkg/scheduler/service/run.go
@@ -219,7 +219,7 @@ func (r *RunRemote) Run(ctx context.Context) error {
 		} else {
 			r.logger().Fatalf("Failed to create worker pool: %s", err)
 		}
-		if features.WorkerpoolOccupancyTrackingEnabled() {
+		if features.Enabled(features.WorkerpoolOccupancyTracking) {
 			//start occupancy tracker to track worker pool
 			err = NewOccupancyTracker(workerPool, r.occupancyRepo, r.config.Scheduler.Reconcilers, r.logger()).Run(ctx)
 			if err == nil {


### PR DESCRIPTION
Applying the IstioOperator chart to the istioctl command from time to time results in an error as reported here: https://github.com/kyma-incubator/reconciler/issues/868
This PR adds a feature flag which enables logging the IstioOperator yaml in case of an error happened on applying it.