### PR TITLE
Adjust info level logs

### DIFF
--- a/pkg/reconciler/service/runner.go
+++ b/pkg/reconciler/service/runner.go
@@ -98,7 +98,7 @@ func (r *runner) Run(ctx context.Context, task *reconciler.Task, callback callba
 
 	processingDuration := time.Since(startTime)
 	if err == nil {
-		r.logger.Infof("Runner: reconciliation of component '%s' for version '%s' finished successfully",
+		r.logger.Debugf("Runner: reconciliation of component '%s' for version '%s' finished successfully",
 			task.Component, task.Version)
 		r.exposeProcessingDuration(reconcilerMetricsSet, task, model.OperationStateDone, processingDuration)
 		if err := heartbeatSender.Success(retryID, processingDuration); err != nil {
@@ -106,7 +106,7 @@ func (r *runner) Run(ctx context.Context, task *reconciler.Task, callback callba
 		} // TODO: enrich heartbeat with processduration
 	} else if ctx.Err() != nil {
 		r.exposeProcessingDuration(reconcilerMetricsSet, task, model.OperationStateFailed, processingDuration)
-		r.logger.Infof("Runner: reconciliation of component '%s' for version '%s' terminated because context was closed",
+		r.logger.Errorf("Runner: reconciliation of component '%s' for version '%s' terminated because context was closed",
 			task.Component, task.Version)
 		return err
 	} else {

--- a/pkg/scheduler/invoker/remoteinvoker.go
+++ b/pkg/scheduler/invoker/remoteinvoker.go
@@ -165,7 +165,7 @@ func (i *RemoteReconcilerInvoker) sendHTTPRequest(params *Params) (*http.Respons
 		return resp, errors.Wrap(err, fmt.Sprintf("failed to call remote reconciler (URL: %s)", compRecon.URL))
 	}
 
-	i.logger.Infof("Remote invoker triggered reconciliation of component '%s' on remote component reconciler '%s': %d",
+	i.logger.Debugf("Remote invoker triggered reconciliation of component '%s' on remote component reconciler '%s': %d",
 		component, compRecon.URL, resp.StatusCode)
 
 	return resp, nil

--- a/pkg/scheduler/reconciliation/persistent.go
+++ b/pkg/scheduler/reconciliation/persistent.go
@@ -130,7 +130,7 @@ func (r *PersistentReconciliationRepository) CreateReconciliation(state *cluster
 			}
 		}
 
-		r.Logger.Infof("ReconRepo created reconciliation (schedulingID:%s) for cluster '%s' including following operations: %s",
+		r.Logger.Debugf("ReconRepo created reconciliation (schedulingID:%s) for cluster '%s' including following operations: %s",
 			reconEntity.SchedulingID, reconEntity.RuntimeID, opsList.String())
 
 		return reconEntity, err

--- a/pkg/scheduler/service/bookkeepingtask.go
+++ b/pkg/scheduler/service/bookkeepingtask.go
@@ -54,7 +54,7 @@ func (fo finishOperation) Apply(reconResult *ReconciliationResult, config *Bookk
 		}
 		if errCnt < config.MaxDeleteErrRetries {
 			newClusterStatus = model.ClusterStatusDeleteErrorRetryable
-			fo.logger.Infof("BookkeeperTask finishOperation: deletion for cluster with runtimeID '%s' and clusterConfig '%d' failed but "+
+			fo.logger.Debugf("BookkeeperTask finishOperation: deletion for cluster with runtimeID '%s' and clusterConfig '%d' failed but "+
 				"deletion will be retried (count of applied retries: %d)",
 				reconResult.reconEntity.RuntimeID, reconResult.reconEntity.ClusterConfig, errCnt)
 		}
@@ -65,7 +65,7 @@ func (fo finishOperation) Apply(reconResult *ReconciliationResult, config *Bookk
 		}
 		if errCnt < config.MaxReconcileErrRetries {
 			newClusterStatus = model.ClusterStatusReconcileErrorRetryable
-			fo.logger.Infof("BookkeeperTask finishOperation: reconciliation for cluster with runtimeID '%s' and clusterConfig '%d' failed but "+
+			fo.logger.Debugf("BookkeeperTask finishOperation: reconciliation for cluster with runtimeID '%s' and clusterConfig '%d' failed but "+
 				"reconciliation will be retried (count of applied retries: %d)",
 				reconResult.reconEntity.RuntimeID, reconResult.reconEntity.ClusterConfig, errCnt)
 		}
@@ -77,7 +77,7 @@ func (fo finishOperation) Apply(reconResult *ReconciliationResult, config *Bookk
 
 	err := fo.transition.FinishReconciliation(recon.SchedulingID, newClusterStatus)
 	if err == nil {
-		fo.logger.Infof("BookkeeperTask finishOperation: updated cluster '%s' to status '%s' (schedulingID:%s)",
+		fo.logger.Debugf("BookkeeperTask finishOperation: updated cluster '%s' to status '%s' (schedulingID:%s)",
 			recon.RuntimeID, newClusterStatus, recon.SchedulingID)
 		return nil
 	}

--- a/pkg/scheduler/service/cleaner.go
+++ b/pkg/scheduler/service/cleaner.go
@@ -189,11 +189,8 @@ func (c *cleaner) purgeReconciliationsOld(transition *ClusterStatusTransition, c
 	}
 
 	for i := range reconciliations {
-		c.logger.Infof("%s Is triggered for the Reconciliation and dependent Operations with SchedulingID '%s' (created: %s)", CleanerPrefix, reconciliations[i].SchedulingID, reconciliations[i].Created)
-
 		id := reconciliations[i].SchedulingID
 		err := transition.ReconciliationRepository().RemoveReconciliationBySchedulingID(id)
-		c.logger.Debugf("%s transition.ReconciliationRepository().RemoveReconciliationBySchedulingID(%s)", CleanerPrefix, id)
 		if err != nil {
 			c.logger.Errorf("%s Failed to remove reconciliation with schedulingID '%s': %s", CleanerPrefix, id, err.Error())
 		}

--- a/pkg/scheduler/service/inventorywatch.go
+++ b/pkg/scheduler/service/inventorywatch.go
@@ -61,7 +61,7 @@ func (w *inventoryWatcher) processClustersToReconcile(queue inventoryQueue) {
 			w.logger.Warn("Inventory watcher found nil cluster state when processing the list of clusters to reconcile")
 			continue
 		}
-		w.logger.Infof("Inventory watcher added runtime '%s' to scheduling queue "+
+		w.logger.Debugf("Inventory watcher added runtime '%s' to scheduling queue "+
 			"(clusterVersion:%d/configVersion:%d/status:%s)",
 			clusterState.Cluster.RuntimeID,
 			clusterState.Cluster.Version, clusterState.Configuration.Version, clusterState.Status.Status)

--- a/pkg/scheduler/service/scheduler.go
+++ b/pkg/scheduler/service/scheduler.go
@@ -109,7 +109,7 @@ func (s *scheduler) Run(ctx context.Context, transition *ClusterStatusTransition
 		select {
 		case clusterState := <-queue:
 			if err := transition.StartReconciliation(clusterState.Cluster.RuntimeID, clusterState.Configuration.Version, config); err == nil {
-				s.logger.Infof("Scheduler triggered reconciliation for cluster '%s' "+
+				s.logger.Debugf("Scheduler triggered reconciliation for cluster '%s' "+
 					"(clusterVersion:%d/configVersion:%d/status:%s/last status update:%.2f min)", clusterState.Cluster.RuntimeID,
 					clusterState.Cluster.Version, clusterState.Configuration.Version, clusterState.Status.Status,
 					time.Since(clusterState.Status.Created).Minutes())

--- a/pkg/scheduler/service/transition.go
+++ b/pkg/scheduler/service/transition.go
@@ -98,14 +98,14 @@ func (t *ClusterStatusTransition) StartReconciliation(runtimeID string, configVe
 			ReconciliationStatus: newClusterState.Status.Status,
 		})
 		if err == nil {
-			t.logger.Infof("Starting reconciliation for cluster '%s' succeeded: reconciliation successfully enqueued "+
+			t.logger.Debugf("Starting reconciliation for cluster '%s' succeeded: reconciliation successfully enqueued "+
 				"(scheudlingID: %s)", newClusterState.Cluster.RuntimeID, reconEntity.SchedulingID)
 			return nil
 		}
 
 		//sort ouf if issue is caused by a race condition (just for logging purpose)
 		if reconciliation.IsDuplicateClusterReconciliationError(err) {
-			t.logger.Infof("Cancelling reconciliation for cluster '%s': cluster is already enqueued (race condition)",
+			t.logger.Warnf("Cancelling reconciliation for cluster '%s': cluster is already enqueued (race condition)",
 				newClusterState.Cluster.RuntimeID)
 		} else {
 			t.logger.Errorf("Starting reconciliation for runtime '%s' failed: "+
@@ -177,7 +177,7 @@ func (t *ClusterStatusTransition) FinishReconciliation(schedulingID string, stat
 
 		err = reconRepo.FinishReconciliation(schedulingID, clusterState.Status)
 		if err == nil {
-			t.logger.Infof("Finishing reconciliation for cluster '%s' succeeded "+
+			t.logger.Debugf("Finishing reconciliation for cluster '%s' succeeded "+
 				"(schedulingID:%s/clusterVersion:%d/configVersion:%d): "+
 				"new cluster status is '%s'", clusterState.Cluster.RuntimeID, schedulingID,
 				clusterState.Cluster.Version, clusterState.Configuration.Version, clusterState.Status.Status)

--- a/pkg/scheduler/worker/workerpool.go
+++ b/pkg/scheduler/worker/workerpool.go
@@ -169,7 +169,7 @@ func (w *Pool) invokeProcessableOps() (int, error) {
 		}
 		op := ops[idx]
 		if err := w.antsPool.Invoke(op); err == nil {
-			w.logger.Infof("Worker pool assigned worker to reconcile component '%s' on cluster '%s' (%s)",
+			w.logger.Debugf("Worker pool assigned worker to reconcile component '%s' on cluster '%s' (%s)",
 				op.Component, op.RuntimeID, op)
 		} else {
 			w.logger.Warnf("Worker pool failed to assign worker to operation '%s': %s", op, err)


### PR DESCRIPTION
Lower following info level logs to debug, or delete if some of them bring not much value.
```
-log:"*Runner: reconciliation of component*"
-log:"*Remote invoker triggered reconciliation of component*"
-log: "*Worker pool assigned worker to reconcile component*"
-log:"*Starting reconciliation for cluster*"
-log:"*Inventory watcher added runtime*" 
-log:"*BookkeeperTask finishOperation*"
-log:"*Finishing reconciliation for cluster*"
-log:"*Scheduler triggered reconciliation for cluster*"
-log:"*ReconRepo created reconciliation*"
-log:"*[CLEANER] Is triggered for the Reconciliation and dependent Operations with SchedulingID*"
```