### PR TITLE
add plan_name for reconciler metrics

### DIFF
--- a/pkg/metrics/reconciliation_status.go
+++ b/pkg/metrics/reconciliation_status.go
@@ -32,7 +32,7 @@ func NewReconciliationStatusCollector() *ReconciliationStatusCollector {
 			Subsystem: prometheusSubsystem,
 			Name:      "reconciliation_status",
 			Help:      "Status of the reconciliation",
-		}, []string{"runtime_id", "runtime_name"}),
+		}, []string{"runtime_id", "runtime_name", "global_accountid", "plan_name"}),
 	}
 	prometheus.MustRegister(collector)
 	return collector
@@ -53,7 +53,7 @@ func (c *ReconciliationStatusCollector) OnClusterStateUpdate(state *cluster.Stat
 	}
 
 	c.reconciliationStatusGauge.
-		WithLabelValues(state.Cluster.RuntimeID, state.Cluster.Runtime.Name).
+		WithLabelValues(state.Cluster.RuntimeID, state.Cluster.Runtime.Name, state.Cluster.Metadata.GlobalAccountID, state.Cluster.Metadata.ServicePlanName).
 		Set(status.ID)
 
 	return nil


### PR DESCRIPTION
Implement task https://github.tools.sap/kyma/backlog/issues/2412 which needs to add global_accountid for distinguish the trial skr or real customer.