### PR TITLE
Avoid logging client-go warnings in production

### DIFF
--- a/cmd/mothership/local/cmd.go
+++ b/cmd/mothership/local/cmd.go
@@ -114,7 +114,7 @@ func RunLocal(o *Options) error {
 	}
 	cluster.Configuration.Components = comps
 
-	runtimeBuilder := schedulerSvc.NewRuntimeBuilder(reconciliation.NewInMemoryReconciliationRepository(), l)
+	runtimeBuilder := schedulerSvc.NewRuntimeBuilder(reconciliation.NewInMemoryReconciliationRepository(), l, o.Verbose)
 	reconResult, err := runtimeBuilder.RunLocal(printStatus).
 		WithSchedulerConfig(
 			&scheduler.SchedulerConfig{

--- a/cmd/mothership/mothership/start/scheduler.go
+++ b/cmd/mothership/mothership/start/scheduler.go
@@ -14,7 +14,7 @@ import (
 
 func startScheduler(ctx context.Context, o *Options) error {
 
-	runtimeBuilder := service.NewRuntimeBuilder(o.Registry.ReconciliationRepository(), logger.NewLogger(o.Verbose))
+	runtimeBuilder := service.NewRuntimeBuilder(o.Registry.ReconciliationRepository(), logger.NewLogger(o.Verbose), o.Verbose)
 	ds, err := service.NewDeleteStrategy(o.Config.Scheduler.DeleteStrategy)
 	if err != nil {
 		return err

--- a/cmd/reconciler/start/service/reconciler.go
+++ b/cmd/reconciler/start/service/reconciler.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+
 	"github.com/kyma-incubator/reconciler/pkg/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -13,7 +14,9 @@ func StartComponentReconciler(ctx context.Context, o *reconCli.Options, reconcil
 	if o.DryRun {
 		service.EnableReconcilerDryRun()
 	}
-
+	if o.Verbose {
+		service.EnableDebug()
+	}
 	durationMetric := metrics.NewComponentProcessingDurationMetric(o.Logger())
 	err := prometheus.Register(durationMetric.Collector)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/fatih/structs v1.1.0
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-git/go-git/v5 v5.4.2
+	github.com/go-logr/logr v0.4.0 // indirect
 	github.com/golang-migrate/migrate/v4 v4.15.1
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/fatih/structs v1.1.0
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-git/go-git/v5 v5.4.2
-	github.com/go-logr/logr v0.4.0 // indirect
+	github.com/go-logr/logr v0.4.0
 	github.com/golang-migrate/migrate/v4 v4.15.1
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.3.0
@@ -81,7 +81,7 @@ require (
 	k8s.io/apimachinery v0.22.5
 	k8s.io/cli-runtime v0.22.5
 	k8s.io/client-go v0.22.5
-	k8s.io/klog/v2 v2.10.0 // indirect
+	k8s.io/klog/v2 v2.10.0
 	k8s.io/kubectl v0.22.5
 	sigs.k8s.io/controller-runtime v0.10.3
 	sigs.k8s.io/yaml v1.2.0

--- a/pkg/reconciler/kubernetes/adapter.go
+++ b/pkg/reconciler/kubernetes/adapter.go
@@ -4,7 +4,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/avast/retry-go"
+	"github.com/go-logr/logr"
 	"github.com/kyma-incubator/reconciler/pkg/reconciler/kubernetes/progress"
 	"helm.sh/helm/v3/pkg/kube"
 	batchv1 "k8s.io/api/batch/v1"
@@ -17,9 +21,8 @@ import (
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/klog/v2"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"strings"
-	"time"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
@@ -78,6 +81,9 @@ func NewKubernetesClient(kubeconfig string, logger *zap.SugaredLogger, config *C
 	apixClient, err := apixV1ClientSet.NewForConfig(restConfig)
 	if err != nil {
 		return nil, err
+	}
+	if !config.Verbose {
+		klog.SetLogger(logr.Discard())
 	}
 	return adapt(kubeconfig, logger, config, restConfig, mapper, dynamicClient, apixClient), err
 }

--- a/pkg/reconciler/kubernetes/adapterconfig.go
+++ b/pkg/reconciler/kubernetes/adapterconfig.go
@@ -17,6 +17,7 @@ type Config struct {
 	ProgressTimeout  time.Duration
 	MaxRetries       int
 	RetryDelay       time.Duration
+	Verbose          bool
 }
 
 func (c *Config) validate() error {

--- a/pkg/reconciler/service/reconciler.go
+++ b/pkg/reconciler/service/reconciler.go
@@ -3,9 +3,10 @@ package service
 import (
 	"context"
 	"fmt"
-	"github.com/kyma-incubator/reconciler/pkg/metrics"
 	"sync"
 	"time"
+
+	"github.com/kyma-incubator/reconciler/pkg/metrics"
 
 	"github.com/kyma-incubator/reconciler/pkg/logger"
 	"github.com/kyma-incubator/reconciler/pkg/reconciler"

--- a/pkg/reconciler/service/registry.go
+++ b/pkg/reconciler/service/registry.go
@@ -6,6 +6,7 @@ import (
 
 var reconcilers = make(map[string]*ComponentReconciler)
 var dryRun bool
+var debug bool
 
 func RegisterReconciler(reconcilerName string, reconciler *ComponentReconciler) {
 	reconcilers[reconcilerName] = reconciler
@@ -17,6 +18,7 @@ func GetReconciler(reconcilerName string) (*ComponentReconciler, error) {
 		return nil, fmt.Errorf("component reconciler '%s' not found in reconciler registry", reconcilerName)
 	}
 	reconciler.EnableDryRun(dryRun)
+	reconciler.debug = debug
 	return reconciler, nil
 }
 
@@ -30,4 +32,8 @@ func RegisteredReconcilers() []string {
 
 func EnableReconcilerDryRun() {
 	dryRun = true
+}
+
+func EnableDebug() {
+	debug = true
 }

--- a/pkg/reconciler/service/runner.go
+++ b/pkg/reconciler/service/runner.go
@@ -140,6 +140,7 @@ func (r *runner) reconcile(ctx context.Context, task *reconciler.Task) error {
 	kubeClient, err := k8s.NewKubernetesClient(task.Kubeconfig, r.logger, &k8s.Config{
 		ProgressInterval: r.progressTrackerConfig.interval,
 		ProgressTimeout:  r.progressTrackerConfig.timeout,
+		Verbose:          r.ComponentReconciler.debug,
 	})
 	if err != nil {
 		return err

--- a/pkg/scheduler/invoker/localinvoker.go
+++ b/pkg/scheduler/invoker/localinvoker.go
@@ -22,13 +22,15 @@ type LocalReconcilerInvoker struct {
 	reconRepo  reconciliation.Repository
 	logger     *zap.SugaredLogger
 	statusFunc ReconcilerStatusFunc
+	debug      bool
 }
 
-func NewLocalReconcilerInvoker(reconRepo reconciliation.Repository, statusFunc ReconcilerStatusFunc, logger *zap.SugaredLogger) *LocalReconcilerInvoker {
+func NewLocalReconcilerInvoker(reconRepo reconciliation.Repository, statusFunc ReconcilerStatusFunc, logger *zap.SugaredLogger, debug bool) *LocalReconcilerInvoker {
 	return &LocalReconcilerInvoker{
 		reconRepo:  reconRepo,
 		logger:     logger,
 		statusFunc: statusFunc,
+		debug:      debug,
 	}
 }
 
@@ -38,7 +40,9 @@ func (i *LocalReconcilerInvoker) Invoke(ctx context.Context, params *Params) err
 			"(schedulingID:%s/correlationID:%s)", params.SchedulingID, params.CorrelationID)
 	}
 	component := params.ComponentToReconcile.Component
-
+	if i.debug {
+		reconRegistry.EnableDebug()
+	}
 	//resolve component reconciler
 	compRecon, err := reconRegistry.GetReconciler(component)
 	if err == nil {

--- a/pkg/scheduler/invoker/localinvoker_test.go
+++ b/pkg/scheduler/invoker/localinvoker_test.go
@@ -80,7 +80,7 @@ func runLocalReconciler(t *testing.T, simulateError bool) (reconciliation.Reposi
 
 	clusterStateMock.Cluster.Kubeconfig = test.ReadKubeconfig(t)
 
-	invoker := NewLocalReconcilerInvoker(reconRepo, callbackFct, logger.NewLogger(true))
+	invoker := NewLocalReconcilerInvoker(reconRepo, callbackFct, logger.NewLogger(true), true)
 	err = invoker.Invoke(ctx, &Params{
 		ComponentToReconcile: &keb.Component{
 			Component:     "unittest", //will trigger the 'unittest' component reconciler created above

--- a/pkg/scheduler/service/run_test.go
+++ b/pkg/scheduler/service/run_test.go
@@ -3,9 +3,10 @@ package service
 import (
 	"context"
 	"fmt"
-	"github.com/kyma-incubator/reconciler/pkg/scheduler/occupancy"
 	"testing"
 	"time"
+
+	"github.com/kyma-incubator/reconciler/pkg/scheduler/occupancy"
 
 	"github.com/google/uuid"
 	"github.com/kyma-incubator/reconciler/pkg/cluster"
@@ -112,7 +113,7 @@ func runRemote(t *testing.T, expectedClusterStatus model.Status, timeout time.Du
 	}()
 
 	//configure remote runner
-	runtimeBuilder := NewRuntimeBuilder(reconRepo, logger.NewLogger(debugLogging))
+	runtimeBuilder := NewRuntimeBuilder(reconRepo, logger.NewLogger(debugLogging), true)
 	remoteRunner := runtimeBuilder.RunRemote(dbConn, inventory, occupancyRepo, &config.Config{
 		Scheme: "https",
 		Host:   "httpbin.org",
@@ -262,7 +263,7 @@ func runLocal(t *testing.T, timeout time.Duration) (*ReconciliationResult, []*re
 	reconRepo := reconciliation.NewInMemoryReconciliationRepository()
 
 	//configure local runner
-	runtimeBuilder := NewRuntimeBuilder(reconRepo, logger.NewLogger(debugLogging))
+	runtimeBuilder := NewRuntimeBuilder(reconRepo, logger.NewLogger(debugLogging), true)
 
 	//use a channel because callbacks are invoked from multiple goroutines
 	callbackData := make(chan *reconciler.CallbackMessage, 10)


### PR DESCRIPTION
Client-go can be a bit chatty with deprecation warnings to make sure users upgrade their resource versions. With the expected scale of the reconciler, this can generate an excessive amount of logs. 

This PR sets a `logr.Discard()` logger for client-go when verbose logging is disabled, effectively masking all warnings and logged errors coming from client-go. All errors are returned from client-go immediately, so this shouldn't mask any bugs. This is not an ideal solution but it's useful in this case considering the resources consumed by these logs.

This option applies to the local reconciler and individual component reconcilers. 