### PR TITLE
upgrade golang to 1.18.0

### DIFF
--- a/Dockerfile.cr
+++ b/Dockerfile.cr
@@ -3,7 +3,7 @@ FROM eu.gcr.io/kyma-project/external/istio/istioctl:1.11.4 AS istio-1_11_4
 FROM eu.gcr.io/kyma-project/external/istio/istioctl:1.12.3 AS istio-1_12_3
 
 # Build image
-FROM golang:1.17.8-alpine3.15 AS build
+FROM golang:1.18.0-alpine3.15 AS build
 
 ENV SRC_DIR=/go/src/github.com/kyma-incubator/reconciler
 COPY . $SRC_DIR

--- a/Dockerfile.mr
+++ b/Dockerfile.mr
@@ -1,5 +1,5 @@
 # Build image
-FROM golang:1.17.8-alpine3.15 AS build
+FROM golang:1.18.0-alpine3.15 AS build
 
 ENV SRC_DIR=/go/src/github.com/kyma-incubator/reconciler
 COPY . $SRC_DIR


### PR DESCRIPTION
fix for https://www.whitesourcesoftware.com/vulnerability-database/CVE-2021-44716