### PR TITLE
Skip migrating instances that don't have SM counterpart

### DIFF
--- a/pkg/reconciler/instances/scmigration/btp_operator_migration.go
+++ b/pkg/reconciler/instances/scmigration/btp_operator_migration.go
@@ -277,6 +277,7 @@ func (m *migrator) getInstancesToMigrate(smInstances *types.ServiceInstances, sv
 				errs = append(errs, err)
 			} else {
 				m.ac.Logger.Info("svcat instance name '%s/%s' id '%s' (%s) not found in SM, skipping", svcat.Namespace, svcat.Name, svcat.Spec.ExternalID, svcat.Name)
+				continue
 			}
 		}
 		svcInstance := svcat


### PR DESCRIPTION
A bug introduced by https://github.com/kyma-incubator/reconciler/pull/955
```
{"level":"INFO","time":"2022-04-06T08:13:19.050Z","message":"migrating service instance 'hb-instbind-redis-1' in namespace 'default' (smID: '0edb5280-5fa3-4974-92a3-138e6970a7f2')","correlation-id":"eb2378de-1e55-47fd-aacc-04ed8c69d360--06d03bf7-6505-40d1-a975-1045f6a8
2022/04/06 08:13:19 worker exits from a panic: runtime error: invalid memory address or nil pointer dereference
2022/04/06 08:13:19 worker exits from panic: goroutine 4084 [running]:
github.com/panjf2000/ants/v2.(*goWorker).run.func1.1()
    /go/pkg/mod/github.com/panjf2000/ants/v2@v2.4.6/worker.go:58 +0x10c
panic({0x21a1520, 0x3b643b0})
    /usr/local/go/src/runtime/panic.go:838 +0x207
github.com/kyma-incubator/reconciler/pkg/reconciler/instances/scmigration.(*migrator).migrateInstance(0xc000a586e0, {0xc0002b0300?, 0x0?})
    /go/src/github.com/kyma-incubator/reconciler/pkg/reconciler/instances/scmigration/btp_operator_migration.go:322 +0x220
github.com/kyma-incubator/reconciler/pkg/reconciler/instances/scmigration.(*migrator).migrateBTPOperator(0xc000a586e0)
    /go/src/github.com/kyma-incubator/reconciler/pkg/reconciler/instances/scmigration/btp_operator_migration.go:191 +0xc89
github.com/kyma-incubator/reconciler/pkg/reconciler/instances/scmigration.(*reconcileAction).Run(0xc0005161a0?, 0xc00004cd70)
    /go/src/github.com/kyma-incubator/reconciler/pkg/reconciler/instances/scmigration/action.go:29 +0x1ae
github.com/kyma-incubator/reconciler/pkg/reconciler/service.(*runner).reconcile(0xc0005d5e90, {0x2910e20?, 0xc0005a2b40}, 0xc000160000)
```