### PR TITLE
Add istioctl 1.13.2 to the Dockerfile

### DIFF
--- a/Dockerfile.cr
+++ b/Dockerfile.cr
@@ -1,6 +1,7 @@
 # Istioctl source images
 FROM eu.gcr.io/kyma-project/external/istio/istioctl:1.11.4 AS istio-1_11_4
 FROM eu.gcr.io/kyma-project/external/istio/istioctl:1.12.3 AS istio-1_12_3
+FROM eu.gcr.io/kyma-project/external/istio/istioctl:1.13.2 AS istio-1_13_2
 
 # Build image
 FROM golang:1.18.0-alpine3.15 AS build
@@ -39,8 +40,9 @@ COPY --from=build /configs/ /configs/
 # Add istioctl tools
 COPY --from=istio-1_11_4 /usr/local/bin/istioctl /bin/istioctl-1.11.4
 COPY --from=istio-1_12_3 /usr/local/bin/istioctl /bin/istioctl-1.12.3
+COPY --from=istio-1_13_2 /usr/local/bin/istioctl /bin/istioctl-1.13.2
 # For multiple istioctl binaries, provide their paths separated with a semicolon (;) like in the Linux PATH variable.
-ENV ISTIOCTL_PATH=/bin/istioctl-1.12.3;/bin/istioctl-1.11.4
+ENV ISTIOCTL_PATH=/bin/istioctl-1.12.3;/bin/istioctl-1.11.4;/bin/istioctl-1.13.2
 
 USER appuser:appuser
 


### PR DESCRIPTION
### Suggested changes

- add `istioctl` binary in version 1.13.2 to the Dockerfile
- extend `ISTIOCTL_PATH` env to include newly-added `istioctl` binary


### Links

- https://github.com/kyma-incubator/reconciler/issues/935