### PR TITLE
Reintroduce audit log

### DIFF
--- a/cmd/mothership/mothership/start/auditlog.go
+++ b/cmd/mothership/mothership/start/auditlog.go
@@ -1,10 +1,22 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/kyma-incubator/reconciler/pkg/keb"
+	"github.com/kyma-incubator/reconciler/pkg/server"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"gopkg.in/natefinch/lumberjack.v2"
-	"net/http"
 )
 
 const (
@@ -56,11 +68,130 @@ func newAuditLoggerMiddelware(l *zap.Logger, o *Options) func(http.Handler) http
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			auditLogRequest(w, r, l, o)
+
 			next.ServeHTTP(w, r)
 		})
 	}
 }
 
+type data struct {
+	ContractVersion int64  `json:"contractVersion"`
+	Method          string `json:"method"`
+	URI             string `json:"uri"`
+	RequestBody     string `json:"requestBody"`
+	User            string `json:"user"`
+	Tenant          string `json:"tenant"`
+	IP              string `json:"ip"`
+}
+
 func auditLogRequest(w http.ResponseWriter, r *http.Request, l *zap.Logger, o *Options) {
-	//TODO Change or remove once Audit Log decision is made
+
+	// Any Audit Log relevant entry will be a stateful change in POST/PUT/PATCH, GET can be ignored
+	if r.Method == http.MethodGet {
+		return
+	}
+
+	params := server.NewParams(r)
+	contractV, err := params.Int64(paramContractVersion)
+	if err != nil {
+
+		server.SendHTTPError(w, http.StatusBadRequest, &keb.HTTPErrorResponse{
+			Error: errors.Wrap(err, "Contract version undefined").Error(),
+		})
+		return
+	}
+	logData := data{
+		ContractVersion: contractV,
+		Method:          r.Method,
+		URI:             r.RequestURI,
+		User:            "UNKNOWN_USER",
+		Tenant:          o.AuditLogTenantID,
+		IP:              "",
+	}
+
+	jwtPayload, err := getJWTPayload(r)
+	if err != nil {
+		server.SendHTTPError(w, http.StatusInternalServerError, &keb.HTTPErrorResponse{
+			Error: errors.Wrap(err, fmt.Sprintf("Failed to parse %s header content ", XJWTHeaderName)).Error(),
+		})
+		return
+	}
+
+	user, err := getJWTPayloadSub(jwtPayload)
+	if err != nil {
+		server.SendHTTPError(w, http.StatusInternalServerError, &keb.HTTPErrorResponse{
+			Error: errors.Wrap(err, "failed to Unmarshal JWT payload").Error(),
+		})
+		return
+	}
+
+	if user != "" {
+		logData.User = user
+	}
+
+	// log request body if needed.
+	if r.Method == "POST" || r.Method == "PUT" {
+		reqBody, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			server.SendHTTPError(w, http.StatusInternalServerError, &keb.HTTPErrorResponse{
+				Error: errors.Wrap(err, "Failed to read received JSON payload").Error(),
+			})
+			return
+		}
+		r.Body = ioutil.NopCloser(bytes.NewBuffer(reqBody))
+		logData.RequestBody = string(reqBody)
+	}
+
+	externalHeaderIP := r.Header.Get(ExternalAddressHeaderName)
+	if externalHeaderIP == "" {
+		o.Logger().Debug(fmt.Sprintf("empty %s header", ExternalAddressHeaderName))
+	} else {
+		logData.IP = externalHeaderIP
+	}
+
+	data, err := json.Marshal(logData)
+	if err != nil {
+		server.SendHTTPError(w, http.StatusInternalServerError, &keb.HTTPErrorResponse{
+			Error: errors.Wrap(err, "Failed to marshal auditlog JSON payload").Error(),
+		})
+		return
+	}
+
+	logger := l.With(zap.String("time", time.Now().Format(time.RFC3339))).
+		With(zap.String("uuid", uuid.New().String())).
+		With(zap.String("user", logData.User)).
+		With(zap.String("data", string(data))).
+		With(zap.String("tenant", o.AuditLogTenantID)).
+		With(zap.String("category", "audit.security-events")) // comply with required log backend format
+
+	if logData.IP != "" {
+		logger = logger.With(zap.String("ip", logData.IP))
+	}
+
+	logger.Info("")
+}
+
+func getJWTPayload(r *http.Request) (string, error) {
+	// The jwtHeader here is not a full JWT token. Instead, it's only the
+	// encoded payload part of the token. It's passed by Istio as a header
+	// since Authz/Authn is done by Istio, and we don't receive the original full JWT token.
+	jwtHeader := r.Header.Get(XJWTHeaderName)
+	if len(jwtHeader) == 0 {
+		return "", nil
+	}
+	decodedSeg, err := base64.RawURLEncoding.DecodeString(jwtHeader)
+	return string(decodedSeg), err
+}
+
+type jwtSub struct {
+	Sub string `json:"sub"`
+}
+
+func getJWTPayloadSub(payload string) (string, error) {
+	if payload == "" {
+		return "", nil
+	}
+	s := jwtSub{}
+	err := json.Unmarshal([]byte(payload), &s)
+	return s.Sub, err
 }

--- a/cmd/mothership/mothership/start/auditlog.go
+++ b/cmd/mothership/mothership/start/auditlog.go
@@ -83,7 +83,7 @@ type data struct {
 
 func auditLogRequest(w http.ResponseWriter, r *http.Request, l *zap.Logger, o *Options) {
 
-	// Any Audit Log relevant entry will be a stateful change in POST/PUT/PATCH, GET can be ignored
+	// Any Audit Log relevant entry will be a stateful change in POST/PUT/PATCH/DELETE, GET can be ignored
 	if r.Method == http.MethodGet {
 		return
 	}

--- a/cmd/mothership/mothership/start/auditlog_test.go
+++ b/cmd/mothership/mothership/start/auditlog_test.go
@@ -1,10 +1,195 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/kyma-incubator/reconciler/internal/cli"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
+const (
+	postKey       = "runtimeID"
+	postValue     = "bb7fb804-ade5-42bc-a740-3c2861d0391d"
+	tenantID      = "5f6b71a9-cd48-448d-9b58-9895f1639bc6"
+	jwtPayloadSub = "test2@test.pl"
+	clientIP      = "1.2.3.4"
+)
+
+type MemorySink struct {
+	*bytes.Buffer
+}
+
+func (s *MemorySink) Close() error { return nil }
+func (s *MemorySink) Sync() error  { return nil }
+
+func testLoggerWithOutput(t *testing.T) (*zap.Logger, *MemorySink) {
+	sink := &MemorySink{&bytes.Buffer{}}
+	err := zap.RegisterSink("memory", func(*url.URL) (zap.Sink, error) {
+		return sink, nil
+	})
+	require.NoError(t, err)
+	cfg := zap.Config{
+		Encoding:         "json",
+		Level:            zap.NewAtomicLevelAt(zapcore.DebugLevel),
+		OutputPaths:      []string{"memory://"},
+		ErrorOutputPaths: []string{"memory://"},
+		EncoderConfig: zapcore.EncoderConfig{
+			MessageKey:   "",
+			LevelKey:     "level",
+			EncodeLevel:  zapcore.CapitalLevelEncoder,
+			TimeKey:      "time",
+			EncodeTime:   zapcore.ISO8601TimeEncoder,
+			EncodeCaller: zapcore.ShortCallerEncoder,
+		},
+	}
+	logger, err := cfg.Build()
+	require.NoError(t, err)
+
+	return logger, sink
+}
+
+type log struct {
+	Time     string `json:"time"`
+	UUID     string `json:"uuid"`
+	User     string `json:"user"`
+	Data     string `json:"data"`
+	Tenant   string `json:"tenant"`
+	IP       string `json:"ip"`
+	Category string `json:"category"`
+}
+
 func Test_Auditlog(t *testing.T) {
-	//TODO Reenable Audit Log Tests or Rewrite
-	t.Skip("Audit Log tests are skipped for now as audit log is disabled")
+	testCases := []struct {
+		name          string
+		method        string
+		body          string
+		jwtHeader     string
+		expectFail    bool
+		addExternalIP bool
+	}{
+		{
+			name:   "get request",
+			method: http.MethodGet,
+		},
+		{
+			name:      "get request with jwtHeader",
+			method:    http.MethodGet,
+			jwtHeader: "eyJleHAiOjQ2ODU5ODk3MDAsImZvbyI6ImJhciIsImlhdCI6MTUzMjM4OTcwMCwiaXNzIjoidGVzdDJAdGVzdC5wbCIsInN1YiI6InRlc3QyQHRlc3QucGwifQ",
+		},
+		{
+			name:   "post request",
+			method: http.MethodPost,
+			body:   fmt.Sprintf(`{"%s":"%s"}`, postKey, postValue),
+		},
+		{
+			name:          "post request",
+			method:        http.MethodPost,
+			body:          fmt.Sprintf(`{"%s":"%s"}`, postKey, postValue),
+			addExternalIP: true,
+		},
+		{
+			name:   "delete request",
+			method: http.MethodDelete,
+		},
+		{
+			name:       "invalid jwtHeader",
+			method:     http.MethodPost,
+			expectFail: true,
+			jwtHeader:  "eyJleHAiOjQ2ODU5ODk3MDAsImZvbyI6ImJhciIsImlhdCI6MTUzMjM4OTcwMCwiaXNzIjoidGVzdDJAdGVzdC5wbCIsInN1YiI6InRlc3QyQHRlc3QucGwifQ==",
+		},
+	}
+
+	// build test logger
+	logger, output := testLoggerWithOutput(t)
+	// build reconciler options
+	o := NewOptions(&cli.Options{})
+	o.AuditLogTenantID = tenantID
+
+	for _, testCase := range testCases {
+		// GIVEN
+		tc := testCase
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+
+			req, _ := http.NewRequest(tc.method, "http://localhost/v1/clusters", nil)
+
+			req = mux.SetURLVars(req, map[string]string{
+				paramContractVersion: "1",
+			})
+
+			if tc.method == http.MethodPost {
+				req.Body = io.NopCloser(bytes.NewBuffer([]byte(tc.body)))
+			}
+
+			if tc.addExternalIP {
+				req.Header.Add(ExternalAddressHeaderName, clientIP)
+			}
+			if tc.jwtHeader != "" {
+				req.Header.Add(XJWTHeaderName, tc.jwtHeader)
+			}
+
+			// clean the log sink
+			defer output.Reset()
+			// WHEN
+			auditLogRequest(w, req, logger, o)
+
+			// THEN
+			if tc.expectFail {
+				require.Equalf(t, http.StatusInternalServerError, w.Result().StatusCode,
+					"expected http status: %v, got: %v",
+					http.StatusInternalServerError, w.Result().StatusCode)
+			} else if tc.method == http.MethodGet {
+				require.Equalf(t, http.StatusOK, w.Result().StatusCode,
+					"expected http status: %v, got: %v",
+					http.StatusOK, w.Result().StatusCode)
+			} else {
+				t.Log(output.String())
+				validateLog(t, output.String(), tc.method, tc.jwtHeader != "", tc.addExternalIP)
+			}
+
+		})
+	}
+}
+
+// validateLog ensures that all required fields in the log message are set and valid. If any of these is missing the audit log backend will not accept/process our logs
+func validateLog(t *testing.T, logMsg, method string, useJWT, checkForValidIP bool) {
+	l := &log{}
+	err := json.Unmarshal([]byte(logMsg), l)
+	require.NoError(t, err)
+
+	require.Falsef(t, l.Time == "" ||
+		l.UUID == "" ||
+		l.User == "" ||
+		l.Data == "" ||
+		l.Tenant == "" ||
+		l.Category == "", "empty log field: %#v", l)
+
+	require.Equalf(t, tenantID, l.Tenant, "invalid log tenantID: expected: %s, got: %s", tenantID, l.Tenant)
+
+	if checkForValidIP {
+		require.NotEmpty(t, l.IP, "invalid log IP: expected non-empty IP, got: %s", clientIP, l.IP)
+		require.NotNil(t, net.ParseIP(l.IP), "invalid log IP: expected valid IP, got: %s", clientIP, l.IP)
+		require.Falsef(t, net.ParseIP(l.IP).IsPrivate(), "invalid log IP: cannot use private ip, got: %s", l.IP)
+	}
+
+	if useJWT {
+		require.Equalf(t, jwtPayloadSub, l.User, "invalid user: expected: %s, got: %s", jwtPayloadSub, l.User)
+	}
+	if method == http.MethodPost {
+		d := &data{}
+		err := json.Unmarshal([]byte(l.Data), d)
+		require.NoError(t, err)
+		require.NotEmptyf(t, d.RequestBody, "empty request body in log message data field: %#v", l.Data)
+	}
 }

--- a/cmd/mothership/mothership/start/http.go
+++ b/cmd/mothership/mothership/start/http.go
@@ -47,14 +47,17 @@ const (
 	paramPoolID     = "poolID"
 )
 
+//AuditRegistry contains mappings from path-prefixes to array of methods that are registered with the AuditLogMiddleware
+type AuditRegistry map[string][]string
+
 var (
-	auditedPaths = []string{
-		fmt.Sprintf("/v{%s}/clusters", paramContractVersion),
-	}
-	auditedMethods = []string{
-		http.MethodPost,
-		http.MethodPut,
-		http.MethodPatch,
+	auditRegistry = AuditRegistry{
+		fmt.Sprintf("/v{%s}/clusters", paramContractVersion): {
+			http.MethodPost,
+			http.MethodPut,
+			http.MethodPatch,
+			http.MethodDelete,
+		},
 	}
 )
 
@@ -174,7 +177,7 @@ func startWebserver(ctx context.Context, o *Options) error {
 		}
 		defer func() { _ = auditLogger.Sync() }() // make golint happy
 		auditLoggerMiddleware := newAuditLoggerMiddleware(auditLogger, o)
-		for _, auditedPath := range auditedPaths {
+		for auditedPath, auditedMethods := range auditRegistry {
 			apiRouter.PathPrefix(auditedPath).Methods(auditedMethods...).Subrouter().Use(auditLoggerMiddleware)
 		}
 	}


### PR DESCRIPTION
this reintroduces the audit log but only for registered endpoints.
it also introduces a test checking that audit log is written correctly.
also removes ip permanently as it can happen that the XFF header is not
set correctly in control plane.

partial fix for #959 