### PR TITLE
Add optional skip for safety check in scmigration

### DIFF
--- a/pkg/reconciler/instances/scmigration/action.go
+++ b/pkg/reconciler/instances/scmigration/action.go
@@ -5,7 +5,7 @@ import (
 )
 
 type reconcileAction struct {
-	// TODO add prometheus metrics
+	skipSafeCheck bool
 }
 
 func (a *reconcileAction) Run(ac *service.ActionContext) error {
@@ -22,7 +22,7 @@ func (a *reconcileAction) Run(ac *service.ActionContext) error {
 		return err
 	}
 	ac.Logger.Infof("Executing SVCAT => BTP Operator CRD migration")
-	m, err := newMigrator(ac)
+	m, err := newMigrator(ac, a.skipSafeCheck)
 	if err != nil {
 		return err
 	}

--- a/pkg/reconciler/instances/scmigration/scmigration.go
+++ b/pkg/reconciler/instances/scmigration/scmigration.go
@@ -1,6 +1,8 @@
 package scmigration
 
 import (
+	"os"
+
 	"github.com/kyma-incubator/reconciler/pkg/logger"
 	"github.com/kyma-incubator/reconciler/pkg/reconciler/service"
 )
@@ -17,5 +19,6 @@ func init() {
 		log.Fatalf("Could not create '%s' component reconciler: %s", ReconcilerName, err)
 	}
 
-	reconciler.WithReconcileAction(&reconcileAction{})
+	skipSafeCheck := os.Getenv("SKIP_SAFE_DELETION_BROKER_CHECK")
+	reconciler.WithReconcileAction(&reconcileAction{skipSafeCheck: skipSafeCheck == "true"})
 }


### PR DESCRIPTION
https://github.com/kyma-incubator/reconciler/pull/955 introduced additional safety check so migration doesn't accidentally delete instances that were supposed to be migrated. This adds control to disable it in form of environment variable `SKIP_SAFE_DELETION_BROKER_CHECK=true`.


