### PR TITLE
Introduce limited Connection Pool Settings

### DIFF
--- a/configs/reconciler.yaml
+++ b/configs/reconciler.yaml
@@ -15,13 +15,13 @@ db:
     useSsl: false
     migrationsDir: "./configs/db/postgres"
     # SetMaxOpenConns sets the maximum number of open connections to the database.
-    maxOpenConns: 0 # if n <= 0, then there is no limit on the number of open connections. The default is 0 (unlimited).
+    maxOpenConns: 50 # if n <= 0, then there is no limit on the number of open connections. The default is 0 (unlimited).
     # SetMaxIdleConns sets the maximum number of connections in the idle connection pool.
-    maxIdleConns: 2 # If n <= 0, no idle connections are retained. The default max idle connections is currently 2. This may change in a future release.
+    maxIdleConns: 20 # If n <= 0, no idle connections are retained. The default max idle connections is currently 2. This may change in a future release.
     # SetConnMaxLifetime sets the maximum amount of time a connection may be reused
-    connMaxLifetime: 0s # If d <= 0, connections are not closed due to a connection's age.
+    connMaxLifetime: 120s # If d <= 0, connections are not closed due to a connection's age.
     # SetConnMaxIdleTime sets the maximum amount of time a connection may be idle.
-    connMaxIdleTime: 0s # If d <= 0, connections are not closed due to a connection's idle time.
+    connMaxIdleTime: 60s # If d <= 0, connections are not closed due to a connection's idle time.
   sqlite:
     file: "reconciler.db"
     deploySchema: true

--- a/configs/reconciler.yaml
+++ b/configs/reconciler.yaml
@@ -15,13 +15,13 @@ db:
     useSsl: false
     migrationsDir: "./configs/db/postgres"
     # SetMaxOpenConns sets the maximum number of open connections to the database.
-    maxOpenConns: 50 # if n <= 0, then there is no limit on the number of open connections. The default is 0 (unlimited).
+    maxOpenConns: 100 # if n <= 0, then there is no limit on the number of open connections. The default is 0 (unlimited).
     # SetMaxIdleConns sets the maximum number of connections in the idle connection pool.
-    maxIdleConns: 20 # If n <= 0, no idle connections are retained. The default max idle connections is currently 2. This may change in a future release.
+    maxIdleConns: 50 # If n <= 0, no idle connections are retained. The default max idle connections is currently 2. This may change in a future release.
     # SetConnMaxLifetime sets the maximum amount of time a connection may be reused
-    connMaxLifetime: 120s # If d <= 0, connections are not closed due to a connection's age.
+    connMaxLifetime: 10m # If d <= 0, connections are not closed due to a connection's age.
     # SetConnMaxIdleTime sets the maximum amount of time a connection may be idle.
-    connMaxIdleTime: 60s # If d <= 0, connections are not closed due to a connection's idle time.
+    connMaxIdleTime: 10m # If d <= 0, connections are not closed due to a connection's idle time.
   sqlite:
     file: "reconciler.db"
     deploySchema: true


### PR DESCRIPTION
This changes the connection pool to be less restrictive and have more reasonable settings. It also setts maxIdleTime which causes the default connection to issue unnecessary many closures of db connections right after an issued statement

relates to #910 
fixes #920 