### PR TITLE
Fix: Change info log to debug log

### DIFF
--- a/pkg/reconciler/instances/clusteressentials/clusteressentials.go
+++ b/pkg/reconciler/instances/clusteressentials/clusteressentials.go
@@ -11,7 +11,7 @@ const ReconcilerName = "cluster-essentials"
 func init() {
 	log := logger.NewLogger(false)
 
-	log.Infof("Initializing component reconciler '%s'", ReconcilerName)
+	log.Debugf("Initializing component reconciler '%s'", ReconcilerName)
 	reconciler, err := service.NewComponentReconciler(ReconcilerName)
 	if err != nil {
 		log.Fatalf("Could not create '%s' component reconciler: %s", ReconcilerName, err)


### PR DESCRIPTION
In the component reconciler of cluster essentials, this log should be a debug log and not info