### PR TITLE
Fix of mismatch of data and control plane blocking istio proxy reset

### DIFF
--- a/pkg/reconciler/instances/istio/action.go
+++ b/pkg/reconciler/instances/istio/action.go
@@ -42,11 +42,6 @@ func (a *StatusPreAction) Run(context *service.ActionContext) error {
 		return err
 	}
 
-	if isMismatchPresent(istioStatus) {
-		errorMessage := fmt.Sprintf("Istio components version mismatch detected: pilot version: %s, data plane version: %s", istioStatus.PilotVersion, istioStatus.DataPlaneVersion)
-		return errors.New(errorMessage)
-	}
-
 	if !isClientCompatibleWithTargetVersion(istioStatus) {
 		return fmt.Errorf("Istio could not be updated since the binary version: %s is not compatible with the target version: %s - the difference between versions exceeds one minor version", istioStatus.ClientVersion, istioStatus.TargetVersion)
 	}
@@ -243,11 +238,6 @@ func (a *ReconcileIstioConfigurationAction) Run(context *service.ActionContext) 
 		return err
 	}
 
-	if isMismatchPresent(istioStatus) {
-		errorMessage := fmt.Sprintf("Istio components version mismatch detected: pilot version: %s, data plane version: %s", istioStatus.PilotVersion, istioStatus.DataPlaneVersion)
-		return errors.New(errorMessage)
-	}
-
 	if !isClientCompatibleWithTargetVersion(istioStatus) {
 		return fmt.Errorf("Istio could not be updated since the binary version: %s is not compatible with the target version: %s - the difference between versions exceeds one minor version", istioStatus.ClientVersion, istioStatus.TargetVersion)
 	}
@@ -414,18 +404,6 @@ func getActionTypeFrom(comparison int) string {
 
 func amongOneMinor(first, second helperVersion) bool {
 	return first.ver.Major == second.ver.Major && (first.ver.Minor == second.ver.Minor || first.ver.Minor-second.ver.Minor == -1 || first.ver.Minor-second.ver.Minor == 1)
-}
-
-func isMismatchPresent(istioStatus actions.IstioStatus) bool {
-	pilot, err := newHelperVersionFrom(istioStatus.PilotVersion)
-	if err != nil {
-		return false
-	}
-	dataPlane, err := newHelperVersionFrom(istioStatus.DataPlaneVersion)
-	if err != nil {
-		return false
-	}
-	return pilot.compare(dataPlane) != 0
 }
 
 func deployIstioResources(context context.Context, chartManifest string, client kubernetes.Client, logger *zap.SugaredLogger) error {

--- a/pkg/reconciler/instances/istio/action_test.go
+++ b/pkg/reconciler/instances/istio/action_test.go
@@ -1224,51 +1224,21 @@ func Test_canUpdate(t *testing.T) {
 		// then
 		require.True(t, result)
 	})
-}
 
-func Test_isMismatchPresent(t *testing.T) {
-	t.Run("should return false if version string is semver incompatible", func(t *testing.T) {
+	t.Run("should allow update when control plane is consistent and not in the same version as data plane", func(t *testing.T) {
 		// given
-		differentVersions := actions.IstioStatus{
-			ClientVersion:    "version1",
-			PilotVersion:     "version2",
-			DataPlaneVersion: "version3",
+		version := actions.IstioStatus{
+			ClientVersion:    "1.2.1",
+			TargetVersion:    "1.2.1",
+			PilotVersion:     "1.2.1",
+			DataPlaneVersion: "1.2.0",
 		}
 
 		// when
-		got := isMismatchPresent(differentVersions)
+		result, _ := canUpdate(version)
 
 		// then
-		require.False(t, got)
-	})
-	t.Run("Different Pilot and DataPlane versions is a mismatch", func(t *testing.T) {
-		// given
-		differentVersions := actions.IstioStatus{
-			ClientVersion:    "1.11.2",
-			PilotVersion:     "1.11.1",
-			DataPlaneVersion: "1.11.2",
-		}
-
-		// when
-		got := isMismatchPresent(differentVersions)
-
-		// then
-		require.True(t, got)
-	})
-
-	t.Run("Same Pilot and DataPlane versions is not a mismatch", func(t *testing.T) {
-		// given
-		sameVersions := actions.IstioStatus{
-			ClientVersion:    "1.11.2",
-			PilotVersion:     "1.11.2",
-			DataPlaneVersion: "1.11.2",
-		}
-
-		// when
-		got := isMismatchPresent(sameVersions)
-
-		// then
-		require.False(t, got)
+		require.True(t, result)
 	})
 }
 

--- a/pkg/reconciler/instances/istio/istio_test.go
+++ b/pkg/reconciler/instances/istio/istio_test.go
@@ -199,7 +199,7 @@ func Test_RunUpdateAction(t *testing.T) {
 		commanderMock.AssertCalled(t, "Version", mock.Anything, mock.Anything)
 	})
 
-	t.Run("Istio update should return an error when there is data plane and pilot version mismatch", func(t *testing.T) {
+	t.Run("Istio update should be allowed when there is data plane and pilot version mismatch if the data plane is consistent", func(t *testing.T) {
 		// given
 		provider := clientset.DefaultProvider{}
 		commanderMock := commandermocks.Commander{}
@@ -212,28 +212,10 @@ func Test_RunUpdateAction(t *testing.T) {
 		err := action.Run(actionContext)
 
 		// then
-		require.Error(t, err)
-		require.EqualError(t, err, "Istio components version mismatch detected: pilot version: 1.13.4, data plane version: 1.13.5")
+		require.NoError(t, err)
 		commanderMock.AssertCalled(t, "Version", mock.Anything, mock.Anything)
 	})
 
-	t.Run("Istio update should return an error when there is data plane and pilot version mismatch", func(t *testing.T) {
-		// given
-		provider := clientset.DefaultProvider{}
-		commanderMock := commandermocks.Commander{}
-		commanderMock.On("Version", mock.Anything, mock.Anything).Return([]byte(istioctlMockDataPlanePilotMismatchVersion), nil)
-		cmdResolver := TestCommanderResolver{cmder: &commanderMock}
-		performer := actions.NewDefaultIstioPerformer(cmdResolver, nil, &provider)
-		action := istio.NewStatusPreAction(performerCreatorFn(performer))
-
-		// when
-		err := action.Run(actionContext)
-
-		// then
-		require.Error(t, err)
-		require.EqualError(t, err, "Istio components version mismatch detected: pilot version: 1.13.4, data plane version: 1.13.5")
-		commanderMock.AssertCalled(t, "Version", mock.Anything, mock.Anything)
-	})
 }
 
 func Test_RunUninstallAction(t *testing.T) {


### PR DESCRIPTION
Mismatch between data and control planes should not block Istio reconcilation if control plane is consistent

Related issue: https://github.com/kyma-incubator/reconciler/issues/1053