### PR TITLE
Add preaction to handle enabling/disabling the jestream with file storage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -101,6 +101,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	helm.sh/helm/v3 v3.7.2
+	sigs.k8s.io/kustomize/kyaml v0.13.0
 )
 
 require (
@@ -265,6 +266,5 @@ require (
 	oras.land/oras-go v0.4.0 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/kustomize/api v0.10.1 // indirect
-	sigs.k8s.io/kustomize/kyaml v0.13.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -104,6 +104,8 @@ require (
 	sigs.k8s.io/kustomize/kyaml v0.13.0
 )
 
+require sigs.k8s.io/kustomize/kyaml v0.13.0
+
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/BurntSushi/toml v0.4.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -104,8 +104,6 @@ require (
 	sigs.k8s.io/kustomize/kyaml v0.13.0
 )
 
-require sigs.k8s.io/kustomize/kyaml v0.13.0
-
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/BurntSushi/toml v0.4.1 // indirect

--- a/pkg/reconciler/instances/eventing/preaction/common.go
+++ b/pkg/reconciler/instances/eventing/preaction/common.go
@@ -1,0 +1,25 @@
+package preaction
+
+import (
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/kubernetes"
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/service"
+	"go.uber.org/zap"
+	"time"
+)
+
+const (
+	namespace = "kyma-system"
+
+	progressTrackerInterval = 5 * time.Second
+	progressTrackerTimeout  = 2 * time.Minute
+)
+
+type kubeClientProvider func(context *service.ActionContext, logger *zap.SugaredLogger) (kubernetes.Client, error)
+
+func defaultKubeClientProvider(context *service.ActionContext, logger *zap.SugaredLogger) (kubernetes.Client, error) {
+	kubeClient, err := kubernetes.NewKubernetesClient(context.Task.Kubeconfig, logger, nil)
+	if err != nil {
+		return nil, err
+	}
+	return kubeClient, nil
+}

--- a/pkg/reconciler/instances/eventing/preaction/handletogglejsfilestorage.go
+++ b/pkg/reconciler/instances/eventing/preaction/handletogglejsfilestorage.go
@@ -1,0 +1,205 @@
+package preaction
+
+import (
+	"fmt"
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/chart"
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/instances/eventing/log"
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/kubernetes/progress"
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/service"
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
+	appsv1 "k8s.io/api/apps/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8s "k8s.io/client-go/kubernetes"
+	"strings"
+)
+
+const (
+	handleEnableJSFileStorageName = "handleToggleJSFileStorage"
+	natsComponentName             = "eventing-nats"
+	statefulSetName               = "eventing-nats"
+	eventingComponentName         = "eventing"
+	fileStorageType               = "file"
+	volumeClaimName               = natsComponentName + "-js-pvc"
+	statefulSetType               = "StatefulSet"
+)
+
+type handleToggleJSFileStorage struct {
+	kubeClientProvider
+}
+
+// newHandleEnableJSFileStorage
+func newHandleToggleJSFileStorage() *handleToggleJSFileStorage {
+	return &handleToggleJSFileStorage{
+		kubeClientProvider: defaultKubeClientProvider,
+	}
+}
+
+// Config holds the global configuration values.
+type Config struct {
+	Global Global
+}
+
+// Global configuration of Jetstream feature.
+type Global struct {
+	Jetstream Jetstream `yaml:"jetstream"`
+}
+
+// Jetstream specific values like enabled flag and storage type.
+type Jetstream struct {
+	Enabled string `yaml:"enabled"`
+	Storage string `yaml:"storage"`
+}
+
+func (r *handleToggleJSFileStorage) Execute(context *service.ActionContext, logger *zap.SugaredLogger) error {
+	// decorate logger
+	logger = logger.With(log.KeyStep, handleEnableJSFileStorageName)
+
+	kubeClient, err := r.kubeClientProvider(context, logger)
+	if err != nil {
+		return err
+	}
+
+	clientSet, err := kubeClient.Clientset()
+	if err != nil {
+		return err
+	}
+
+	statefulSet, err := clientSet.AppsV1().StatefulSets(namespace).Get(context.Context, statefulSetName, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			logger.With(log.KeyReason, "Nats StatefulSet not found").Info("Step skipped")
+			return nil
+		}
+		return err
+	}
+
+	tracker, err := progress.NewProgressTracker(clientSet, logger, progress.Config{Interval: progressTrackerInterval, Timeout: progressTrackerTimeout})
+	if err != nil {
+		return err
+	}
+
+	comp := chart.NewComponentBuilder(context.Task.Version, eventingComponentName).
+		WithConfiguration(context.Task.Configuration).
+		WithNamespace(namespace).
+		Build()
+
+	chartValues, err := context.ChartProvider.Configuration(comp)
+	if err != nil {
+		return err
+	}
+
+	data, err := yaml.Marshal(chartValues)
+	if err != nil {
+		return err
+	}
+
+	values := &Config{}
+	if err := yaml.Unmarshal(data, &values); err != nil {
+		return err
+	}
+
+	// fetch Jetstream configuration
+	jetstreamEnabled := fmt.Sprint(values.Global.Jetstream.Enabled) == "true"
+	storageType := fmt.Sprint(values.Global.Jetstream.Storage)
+
+	// check if the Jetstream PVC is in place
+	volumeClaimTemplateFound := false
+	for _, volumeClaimTemplate := range statefulSet.Spec.VolumeClaimTemplates {
+		if strings.EqualFold(volumeClaimTemplate.Name, volumeClaimName) {
+			volumeClaimTemplateFound = true
+		}
+	}
+
+	//Scenario 1: migrate from NATS to NATS Jetstream with file storage
+	//as the statefulSet's spec is immutable, we cannot patch in order to add a PVC, hence statefulSet must be recreated
+	if jetstreamEnabled && strings.EqualFold(fileStorageType, fmt.Sprint(storageType)) {
+		if !volumeClaimTemplateFound {
+			if err := deleteNatsStatefulSet(context, clientSet, tracker, logger, statefulSet, false); err != nil {
+				return err
+			}
+		} else {
+			logger.With(log.KeyReason, "Nats StatefulSet already contains a PVC").Info("Step skipped")
+		}
+		return nil
+	}
+
+	// Scenario 2: migrate from NATS Jetstream with file storage to NATS
+	// as the statefulSet's spec is immutable, we cannot patch it. Hence, in order to remove a PVC, the StatefulSet must be recreated
+	if !jetstreamEnabled && volumeClaimTemplateFound {
+		if err := deleteNatsStatefulSet(context, clientSet, tracker, logger, statefulSet, true); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	logger.With(log.KeyReason, "No actions needed").Info("Step skipped")
+	return nil
+}
+
+// deleteNatsStatefulSet delete the Nats StatefulSet and optionally its assigned PVC.
+func deleteNatsStatefulSet(context *service.ActionContext, clientSet k8s.Interface, tracker *progress.Tracker, logger *zap.SugaredLogger, statefulSet *appsv1.StatefulSet, deletePVC bool) error {
+	// In case of switching from Nats Jestream to NATS the PVCs assigned to the Nats Stateful set should be deleted
+	if deletePVC {
+		err := deleteNatsJsPVC(context, statefulSet, clientSet, logger)
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := addToProgressTracker(tracker, logger, statefulSetType, statefulSetName); err != nil {
+		return err
+	}
+	logger.Info("Deleting nats StatefulSet in order to perform the PVC migration")
+	if err := clientSet.AppsV1().StatefulSets(namespace).Delete(context.Context, statefulSetName, metav1.DeleteOptions{}); err != nil {
+		return err
+	}
+
+	// wait until StatefulSet is deleted
+	if err := tracker.Watch(context.Context, progress.TerminatedState); err != nil {
+		logger.Warnf("Watching progress of deleted resources failed: %s", err)
+		return err
+	}
+	return nil
+}
+
+// deleteNatsJsPVC removes the PVCs assigned to nats pods.
+func deleteNatsJsPVC(context *service.ActionContext, statefulSet *appsv1.StatefulSet, clientSet k8s.Interface, logger *zap.SugaredLogger) error {
+	replicas := statefulSet.Spec.Replicas
+	for i := 0; i < int(*replicas); i++ {
+		// build the pvc name from the pod's name
+		pvcName := volumeClaimName + "-" + statefulSetName + "-" + fmt.Sprint(i)
+		pvc, err := clientSet.CoreV1().PersistentVolumeClaims(namespace).Get(context.Context, pvcName, metav1.GetOptions{})
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+
+		if pvc != nil {
+			logger.Infof("Deleting nats Jestream PVC %s", pvcName)
+			if err := clientSet.CoreV1().PersistentVolumeClaims(namespace).Delete(context.Context, pvcName, metav1.DeleteOptions{}); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// addToProgressTracker adds the given resource to the progress tracker.
+func addToProgressTracker(tracker *progress.Tracker, logger *zap.SugaredLogger, resourceType string, resourceName string) error {
+	//if resource is watchable, add it to progress tracker
+	watchable, err := progress.NewWatchableResource(resourceType)
+	//add only watchable resources to progress tracker
+	if err == nil {
+		tracker.AddResource(watchable, namespace, resourceName)
+	} else {
+		logger.Infof("Cannot add the resource kind: %s, name: %s to watchables", resourceType, resourceName)
+	}
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/reconciler/instances/eventing/preaction/handletogglejsfilestorage_test.go
+++ b/pkg/reconciler/instances/eventing/preaction/handletogglejsfilestorage_test.go
@@ -1,0 +1,273 @@
+package preaction
+
+import (
+	"context"
+	"fmt"
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/instances/eventing/log"
+	k8s "github.com/kyma-incubator/reconciler/pkg/reconciler/kubernetes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+	"testing"
+
+	chartmocks "github.com/kyma-incubator/reconciler/pkg/reconciler/chart/mocks"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kyma-incubator/reconciler/pkg/logger"
+	"github.com/kyma-incubator/reconciler/pkg/reconciler"
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/kubernetes/mocks"
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/service"
+)
+
+const pvcName = volumeClaimName + "-" + statefulSetName + "-"
+
+func TestToggleJsFileStoragePreAction(t *testing.T) {
+	const memoryStorageType = "memory"
+
+	defaultStatefulSet := newStatefulSet()
+	testCases := []struct {
+		name             string
+		givenStatefulSet *appsv1.StatefulSet
+		givenJsEnabled   bool
+		givenStorageType string
+		givenPVC         bool
+		wantStatefulSet  *appsv1.StatefulSet
+		wantPVCDeletion  bool
+	}{
+		{
+			name:             "Should do nothing if Nats StatefulSet is not found with JS disabled",
+			givenJsEnabled:   false,
+			givenStorageType: fileStorageType,
+			givenStatefulSet: nil,
+			givenPVC:         false,
+			wantStatefulSet:  nil,
+		},
+		{
+			name:             "Should do nothing if Nats StatefulSet is not found with JS enabled and file storage",
+			givenJsEnabled:   false,
+			givenStorageType: fileStorageType,
+			givenStatefulSet: nil,
+			givenPVC:         false,
+			wantStatefulSet:  nil,
+		},
+		{
+			name:             "Should do nothing if Nats StatefulSet is not found with JS enabled and memory storage",
+			givenJsEnabled:   true,
+			givenStorageType: memoryStorageType,
+			givenStatefulSet: nil,
+			givenPVC:         false,
+			wantStatefulSet:  nil,
+		},
+		{
+			name:             "Should do nothing if Nats Jetstream is disabled and there is no PVC",
+			givenStatefulSet: defaultStatefulSet,
+			givenJsEnabled:   false,
+			givenPVC:         false,
+			wantStatefulSet:  defaultStatefulSet,
+		},
+		{
+			name:             "Should delete the StatefulSet if Nats Jetstream is disabled, but there is a PVC",
+			givenStatefulSet: newStatefulSet(withVolumeClaimTemplates()),
+			givenJsEnabled:   false,
+			givenPVC:         true,
+			wantStatefulSet:  nil,
+		},
+		{
+			name:             "Should delete the StatefulSet if Nats Jetstream is enabled with file storage type and there is no PVC",
+			givenStatefulSet: defaultStatefulSet,
+			givenJsEnabled:   true,
+			givenStorageType: fileStorageType,
+			givenPVC:         false,
+			wantStatefulSet:  nil,
+		},
+		{
+			name:             "Should do nothing if Nats Jetstream is enabled with file storage type and there is a PVC",
+			givenStatefulSet: defaultStatefulSet,
+			givenJsEnabled:   true,
+			givenStorageType: fileStorageType,
+			givenPVC:         false,
+			wantStatefulSet:  nil,
+		},
+		{
+			name: "Should delete the StatefulSet and the PVC if Nats Jetstream is disabled and there is a PVC left",
+			givenStatefulSet: newStatefulSet(
+				withVolumeClaimTemplates(),
+			),
+			givenJsEnabled:   false,
+			givenStorageType: fileStorageType,
+			givenPVC:         true,
+			wantStatefulSet:  nil,
+			wantPVCDeletion:  true,
+		},
+		{
+			name: "Should delete the StatefulSet and all the PVCs if Nats Jetstream is disabled and there are still PVCs left",
+			givenStatefulSet: newStatefulSet(
+				withReplicas(2),
+				withVolumeClaimTemplates(),
+			),
+			givenJsEnabled:   false,
+			givenStorageType: fileStorageType,
+			wantStatefulSet:  nil,
+			wantPVCDeletion:  true,
+		},
+	}
+
+	setup := func(t *testing.T, jsEnabled bool, storageType string) (kubernetes.Interface, handleToggleJSFileStorage, *service.ActionContext) {
+		k8sClient := fake.NewSimpleClientset()
+		mockClient := mocks.Client{}
+		mockClient.On("Clientset").Return(k8sClient, nil)
+		action := handleToggleJSFileStorage{
+			kubeClientProvider: func(context *service.ActionContext, logger *zap.SugaredLogger) (k8s.Client, error) {
+				return &mockClient, nil
+			},
+		}
+
+		chartProvider := &chartmocks.Provider{}
+		chartValuesYAML := getJestreamValuesYAML(jsEnabled, storageType)
+		chartValues, err := unmarshalTestValues(chartValuesYAML)
+		require.NoError(t, err)
+
+		chartProvider.On("Configuration", mock.Anything).Return(chartValues, nil)
+
+		actionContext := &service.ActionContext{
+			KubeClient:    &mockClient,
+			Context:       context.TODO(),
+			Logger:        logger.NewLogger(false),
+			Task:          &reconciler.Task{Version: "test"},
+			ChartProvider: chartProvider,
+		}
+		return k8sClient, action, actionContext
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// given
+			var err error
+			k8sClient, action, actionContext := setup(t, tc.givenJsEnabled, tc.givenStorageType)
+
+			if tc.givenStatefulSet != nil {
+				_, err = createStatefulSet(actionContext.Context, k8sClient, tc.givenStatefulSet)
+				require.NoError(t, err)
+			}
+
+			if tc.givenStatefulSet != nil && tc.givenPVC {
+				// create PVCs according to replicas number
+				replicas := int(*tc.givenStatefulSet.Spec.Replicas)
+				if replicas > 0 {
+					for i := 0; i < replicas; i++ {
+						err := createPVC(actionContext.Context, k8sClient, pvcName+fmt.Sprint(i))
+						require.NoError(t, err)
+					}
+					list, err := k8sClient.CoreV1().PersistentVolumeClaims(namespace).List(actionContext.Context, metav1.ListOptions{})
+					require.NoError(t, err)
+					assert.Equal(t, replicas, len(list.Items))
+				}
+			}
+
+			// when
+			err = action.Execute(actionContext, log.ContextLogger(actionContext, log.WithAction(actionName)))
+			require.NoError(t, err)
+
+			// then
+			gotStatefulSet, err := k8sClient.AppsV1().StatefulSets(namespace).Get(actionContext.Context, statefulSetName, metav1.GetOptions{})
+			if !k8serrors.IsNotFound(err) {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.wantStatefulSet, gotStatefulSet)
+
+			if tc.wantPVCDeletion {
+				// check if all the PVC instances were deleted
+				list, err := k8sClient.CoreV1().PersistentVolumeClaims(namespace).List(actionContext.Context, metav1.ListOptions{})
+				require.NoError(t, err)
+				assert.Equal(t, 0, len(list.Items))
+			}
+		})
+	}
+}
+
+type statefulSetOpt func(set *appsv1.StatefulSet)
+
+func newStatefulSet(opts ...statefulSetOpt) *appsv1.StatefulSet {
+	replicas := int32(1)
+	statefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      statefulSetName,
+			Namespace: namespace,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+		},
+	}
+
+	for _, opt := range opts {
+		opt(statefulSet)
+	}
+
+	return statefulSet
+}
+
+func withReplicas(replicas int) statefulSetOpt {
+	return func(statefulSet *appsv1.StatefulSet) {
+		ssReplicas := int32(replicas)
+		statefulSet.Spec.Replicas = &ssReplicas
+	}
+}
+
+func withVolumeClaimTemplates() statefulSetOpt {
+	return func(statefulSet *appsv1.StatefulSet) {
+		var persistentVolumeClaims []v1.PersistentVolumeClaim
+		pvc := v1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      volumeClaimName,
+				Namespace: namespace,
+			},
+		}
+		persistentVolumeClaims = append(persistentVolumeClaims, pvc)
+		statefulSet.Spec.VolumeClaimTemplates = persistentVolumeClaims
+	}
+}
+
+func getJestreamValuesYAML(jsEnabled bool, fileStorage string) string {
+	return fmt.Sprintf(`
+    global:
+      jetstream:
+        enabled: %s
+        storage: %s`,
+		fmt.Sprint(jsEnabled),
+		fileStorage,
+	)
+}
+
+func unmarshalTestValues(yamlValues string) (map[string]interface{}, error) {
+	var values map[string]interface{}
+	err := yaml.Unmarshal([]byte(yamlValues), &values)
+	if err != nil {
+		return nil, err
+	}
+	return values, nil
+}
+
+func createStatefulSet(ctx context.Context, client kubernetes.Interface, statefulSet *appsv1.StatefulSet) (*appsv1.StatefulSet, error) {
+	return client.AppsV1().StatefulSets(statefulSet.Namespace).Create(ctx, statefulSet, metav1.CreateOptions{})
+}
+
+func createPVC(ctx context.Context, client kubernetes.Interface, name string) error {
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	if _, err := client.CoreV1().PersistentVolumeClaims(namespace).Create(ctx, pvc, metav1.CreateOptions{}); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/reconciler/instances/eventing/preaction/preaction.go
+++ b/pkg/reconciler/instances/eventing/preaction/preaction.go
@@ -12,5 +12,6 @@ const (
 func New() *action.Action {
 	return action.New(actionName, action.Steps{
 		// add PreAction steps here
+		newHandleToggleJSFileStorage(),
 	})
 }


### PR DESCRIPTION
**Description**

When switching from NATS to NATS Jestream with file storage or the other way around we get the PATCH-action error: 
` kubeClient failed to update StatefulSet 'eventing-nats' (namespace: kyma-system)  with strategy 'PATCH': cannot patch "eventing-nats" with kind StatefulSet: StatefulSet.apps "eventing-nats" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden` 
To fix that we need to recreate the StatefulSet, and in that case the it will be recreated with the updated PVC configuration.

**Changes proposed in this Pull Request**
1. Scenario NATS -> NATS Jetstream with file storage:
    - check that js is enabled and file storage mode is set and remove delete the StatefulSet, so that it would get recreated in the helm charts apply step
2. Scenario NATS Jetstream with file storage -> NATS:
    - check if the jestream is disabled, but there is PVC part in StatefulSet: delete the StatefulSet and remove the orphan PVC(s).

**Related Issue**
https://github.com/kyma-project/kyma/issues/13777