### PR TITLE
refresh eventing code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,7 +8,7 @@
 /pkg/reconciler/instances/istio/ @strekm @werdes72 @Tomasz-Smelcerz-SAP @mjakobczyk @dariusztutaj @cnvergence @veichtj @piotrkpc
 
 # Eventing reconciler
-/pkg/reconciler/instances/eventing/ @lilitgh @k15r @nachtmaar @marcobebway @radufa @sayanh @pxsalehi @mfaizanse
+/pkg/reconciler/instances/eventing/ @k15r @nachtmaar @marcobebway @pxsalehi @mfaizanse @friedrichwilken @vladislavpaskar @raypinto @lilitgh
 
 # Serverless reconciler
 /pkg/reconciler/instances/serverless/ @m00g3n @pPrecel @dbadura @rJankowski93


### PR DESCRIPTION
this PR adds @mfaizanse @friedrichwilken @vladislavpaskar @raypinto and removes @radufa as code owners for eventing.