### PR TITLE
Fix: Istio proxy path bug in performer

### DIFF
--- a/pkg/reconciler/instances/istio/actions/performer.go
+++ b/pkg/reconciler/instances/istio/actions/performer.go
@@ -377,10 +377,10 @@ func getTargetVersionFromIstioChart(workspace chart.Factory, branch string, isti
 		return pilotVersion, nil
 	}
 
-	appVersion := getTargetVersionFromAppVersionInChartDefinition(istioHelmChart)
-	if appVersion != "" {
-		logger.Debugf("Resolved target Istio version: %s from Chart definition", appVersion)
-		return appVersion, nil
+	chartVersion := getTargetVersionFromVersionInChartDefinition(istioHelmChart)
+	if chartVersion != "" {
+		logger.Debugf("Resolved target Istio version: %s from Chart definition", chartVersion)
+		return chartVersion, nil
 	}
 
 	return "", errors.New("Target Istio version could not be found neither in Chart.yaml nor in helm values")
@@ -421,8 +421,8 @@ func getTargetProxyV2PrefixFromIstioChart(workspace chart.Factory, branch string
 	return "", errors.New("Could not resolve target proxyV2 Istio prefix from values")
 }
 
-func getTargetVersionFromAppVersionInChartDefinition(helmChart *helmChart.Chart) string {
-	return helmChart.Metadata.AppVersion
+func getTargetVersionFromVersionInChartDefinition(helmChart *helmChart.Chart) string {
+	return helmChart.Metadata.Version
 }
 
 func getTargetVersionFromPilotInChartValues(helmChart *helmChart.Chart) (string, error) {

--- a/pkg/reconciler/instances/istio/actions/performer.go
+++ b/pkg/reconciler/instances/istio/actions/performer.go
@@ -403,7 +403,7 @@ func getTargetProxyV2PrefixFromIstioChart(workspace chart.Factory, branch string
 	}
 
 	if istioValuesDirectory != "" && istioValuesRegistryPath != "" {
-		prefix := fmt.Sprintf("%s/%s", istioValuesDirectory, istioValuesRegistryPath)
+		prefix := fmt.Sprintf("%s/%s", istioValuesRegistryPath, istioValuesDirectory)
 		logger.Debugf("Resolved target Istio prefix: %s from istio values.yaml", prefix)
 		return prefix, nil
 	}

--- a/pkg/reconciler/instances/istio/actions/performer_test.go
+++ b/pkg/reconciler/instances/istio/actions/performer_test.go
@@ -646,21 +646,6 @@ func Test_getTargetVersionFromIstioChart(t *testing.T) {
 		require.Contains(t, err.Error(), "no such file or directory")
 	})
 
-	t.Run("should not get target version when the istio Chart does not contain definition and values", func(t *testing.T) {
-		// given
-		istioChart := "istio-no-values-no-appversion"
-		factory := &workspacemocks.Factory{}
-		factory.On("Get", mock.AnythingOfType("string")).Return(&chart.KymaWorkspace{ResourceDir: "../test_files"}, nil)
-
-		// when
-		targetVersion, err := getTargetVersionFromIstioChart(factory, branch, istioChart, log)
-
-		// then
-		require.Empty(t, targetVersion)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "Target Istio version could not be found neither in Chart.yaml nor in helm values")
-	})
-
 	t.Run("should return pilot version from values when version was found in values", func(t *testing.T) {
 		// given
 		istioChart := "istio-values-appversion"
@@ -686,7 +671,7 @@ func Test_getTargetVersionFromIstioChart(t *testing.T) {
 
 		// then
 		require.NoError(t, err)
-		require.EqualValues(t, "1.2.3", targetVersion)
+		require.EqualValues(t, "1.2.3-distroless", targetVersion)
 	})
 
 	t.Run("should fallback to chart appVersion when values.yaml is not present in the chart", func(t *testing.T) {
@@ -700,7 +685,7 @@ func Test_getTargetVersionFromIstioChart(t *testing.T) {
 
 		// then
 		require.NoError(t, err)
-		require.EqualValues(t, "1.2.3", targetVersion)
+		require.EqualValues(t, "1.2.3-distroless", targetVersion)
 	})
 }
 


### PR DESCRIPTION
Changes:
 - fix to the container image path on Istio helm-chart
 - change appVersion to version
 
Previous reworks caused an issue which resulted in misbehaviour of Istio proxy reset in both latest and 2.0 Kyma versions
In istio-configuration, the proper version was held in version instead of appVersion.

Issue:
- https://github.com/kyma-incubator/reconciler/issues/1079