### PR TITLE
Enable debug logs for KCP CLI

### DIFF
--- a/cmd/mothership/mothership/start/http.go
+++ b/cmd/mothership/mothership/start/http.go
@@ -181,12 +181,12 @@ func startWebserver(ctx context.Context, o *Options) error {
 	apiRouter.HandleFunc(
 		fmt.Sprintf("/v{%s}/operations/{%s}/{%s}/debug", paramContractVersion, paramSchedulingID, paramCorrelationID),
 		callHandler(o, enableOperationDebugLogging)).
-		Methods(http.MethodPost)
+		Methods(http.MethodPut)
 
 	apiRouter.HandleFunc(
 		fmt.Sprintf("/v{%s}/reconciliations/{%s}/debug", paramContractVersion, paramSchedulingID),
 		callHandler(o, enableReconciliationDebugLogging)).
-		Methods(http.MethodPost)
+		Methods(http.MethodPut)
 
 	apiRouter.HandleFunc(
 		fmt.Sprintf("/v{%s}/clusters/{%s}/config/{%s}", paramContractVersion, paramRuntimeID, paramConfigVersion),

--- a/cmd/mothership/mothership/start/http.go
+++ b/cmd/mothership/mothership/start/http.go
@@ -252,6 +252,7 @@ func enableReconciliationDebugLogging(o *Options, w http.ResponseWriter, r *http
 		server.SendHTTPErrorMap(w, err)
 		return
 	}
+	w.WriteHeader(http.StatusOK)
 }
 
 func enableOperationDebugLogging(o *Options, w http.ResponseWriter, r *http.Request) {
@@ -281,6 +282,7 @@ func enableOperationDebugLogging(o *Options, w http.ResponseWriter, r *http.Requ
 		server.SendHTTPErrorMap(w, err)
 		return
 	}
+	w.WriteHeader(http.StatusOK)
 
 }
 

--- a/cmd/mothership/mothership/start/http.go
+++ b/cmd/mothership/mothership/start/http.go
@@ -237,7 +237,7 @@ func startWebserver(ctx context.Context, o *Options) error {
 func enableReconciliationDebugLogging(o *Options, w http.ResponseWriter, r *http.Request) {
 
 	if !features.Enabled(features.DebugLogForSpecificOperations) {
-		err := fmt.Errorf("enabling debug logs for a reconciliation is disabled")
+		err := errors.New("enabling debug logs for a reconciliation is disabled")
 		server.SendHTTPErrorMap(w, err)
 		return
 	}
@@ -258,7 +258,7 @@ func enableReconciliationDebugLogging(o *Options, w http.ResponseWriter, r *http
 func enableOperationDebugLogging(o *Options, w http.ResponseWriter, r *http.Request) {
 
 	if !features.Enabled(features.DebugLogForSpecificOperations) {
-		err := fmt.Errorf("enabling debug logs for an operation is disabled")
+		err := errors.New("enabling debug logs for an operation is disabled")
 		server.SendHTTPErrorMap(w, err)
 		return
 	}

--- a/cmd/mothership/mothership/start/http.go
+++ b/cmd/mothership/mothership/start/http.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/kyma-incubator/reconciler/pkg/db"
 	"github.com/kyma-incubator/reconciler/pkg/features"
 
@@ -976,13 +975,6 @@ func createOrUpdateComponentWorkerPoolOccupancy(o *Options, w http.ResponseWrite
 func deleteComponentWorkerPoolOccupancy(o *Options, w http.ResponseWriter, r *http.Request) {
 	params := server.NewParams(r)
 	poolID, err := params.String(paramPoolID)
-	if err != nil {
-		server.SendHTTPError(w, http.StatusBadRequest, &reconciler.HTTPErrorResponse{
-			Error: err.Error(),
-		})
-		return
-	}
-	_, err = uuid.Parse(poolID)
 	if err != nil {
 		server.SendHTTPError(w, http.StatusBadRequest, &reconciler.HTTPErrorResponse{
 			Error: err.Error(),

--- a/cmd/mothership/mothership/start/http.go
+++ b/cmd/mothership/mothership/start/http.go
@@ -237,7 +237,8 @@ func startWebserver(ctx context.Context, o *Options) error {
 func enableReconciliationDebugLogging(o *Options, w http.ResponseWriter, r *http.Request) {
 
 	if !features.Enabled(features.DebugLogForSpecificOperations) {
-		w.WriteHeader(http.StatusNotFound)
+		err := fmt.Errorf("enabling debug logs for a reconciliation is disabled")
+		server.SendHTTPErrorMap(w, err)
 		return
 	}
 	params := server.NewParams(r)
@@ -256,7 +257,8 @@ func enableReconciliationDebugLogging(o *Options, w http.ResponseWriter, r *http
 func enableOperationDebugLogging(o *Options, w http.ResponseWriter, r *http.Request) {
 
 	if !features.Enabled(features.DebugLogForSpecificOperations) {
-		w.WriteHeader(http.StatusNotFound)
+		err := fmt.Errorf("enabling debug logs for an operation is disabled")
+		server.SendHTTPErrorMap(w, err)
 		return
 	}
 	params := server.NewParams(r)

--- a/openapi/external_api.yaml
+++ b/openapi/external_api.yaml
@@ -58,6 +58,7 @@ paths:
                 $ref: '#/components/schemas/HTTPErrorResponse'
         '500':
           $ref: '#/components/responses/InternalError'
+
   /operations/{schedulingID}/{correlationID}/debug:
     put:
       description: "Enable debug logs for an operation"
@@ -79,13 +80,14 @@ paths:
         "400":
           $ref: "#/components/responses/BadRequest"
         "404":
-          description: "Given operation not found"
+          description: "Given operation is not found"
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPErrorResponse"
         "500":
           $ref: "#/components/responses/InternalError"
+
   /reconciliations/{schedulingID}/info:
     get:
       description: "Get details of a reconciliation with operations"

--- a/openapi/external_api.yaml
+++ b/openapi/external_api.yaml
@@ -58,6 +58,34 @@ paths:
                 $ref: '#/components/schemas/HTTPErrorResponse'
         '500':
           $ref: '#/components/responses/InternalError'
+  /operations/{schedulingID}/{correlationID}/debug:
+    put:
+      description: "Enable debug logs for an operation"
+      parameters:
+        - name: schedulingID
+          required: true
+          in: path
+          schema:
+            type: string
+        - name: correlationID
+          required: true
+          in: path
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: "Ok"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          description: "Given operation not found"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HTTPErrorResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
   /reconciliations/{schedulingID}/info:
     get:
       description: "Get details of a reconciliation with operations"
@@ -74,6 +102,29 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "404":
           $ref: "#/components/responses/NotFoundResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /reconciliations/{schedulingID}/debug:
+    put:
+      description: "Enable debug logs for all operations that belong to a reconciliation"
+      parameters:
+        - name: schedulingID
+          required: true
+          in: path
+          schema:
+            type: string
+      responses:
+        "200":
+          description: "Ok"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          description: "Given reconciliation is not found"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HTTPErrorResponse"
         "500":
           $ref: "#/components/responses/InternalError"
 


### PR DESCRIPTION
**Changes proposed in this PR**

- changed debug endpoints HTTP method from POST to PUT as they are idempotent operations
- changed error code when debug logs feature is disabled
- updated open API external spec for KCP CLI


**Related Issues**
#949 