### PR TITLE
Only patch new istio webhook

### DIFF
--- a/pkg/reconciler/instances/istio/actions/performer_test.go
+++ b/pkg/reconciler/instances/istio/actions/performer_test.go
@@ -245,7 +245,7 @@ func Test_DefaultIstioPerformer_PatchMutatingWebhook(t *testing.T) {
 
 	t.Run("should patch MutatingWebhookConfiguration when kubeclient had not returned an error", func(t *testing.T) {
 		// given
-		whConfName := "istio-sidecar-injector"
+		whConfName := "istio-revision-tag-default"
 		kubeClient := mocks.Client{}
 		clientset := fake.NewSimpleClientset(createIstioAutoMutatingWebhookConf(whConfName))
 		kubeClient.On("Clientset").Return(clientset, nil)

--- a/pkg/reconciler/instances/istio/istio_test.go
+++ b/pkg/reconciler/instances/istio/istio_test.go
@@ -287,7 +287,7 @@ func newFakeKubeClient() *k8smocks.Client {
 		},
 	},
 		&v12.MutatingWebhookConfiguration{
-			ObjectMeta: metav1.ObjectMeta{Name: "istio-sidecar-injector"},
+			ObjectMeta: metav1.ObjectMeta{Name: "istio-revision-tag-default"},
 			Webhooks: []v12.MutatingWebhook{
 				{
 					Name: "auto.sidecar-injector.istio.io",


### PR DESCRIPTION
Remove logic to patch either the old istio webhook (<1.12) or the new one. Just rely on new existing one.