### PR TITLE
Add an eventing preaction to handle the Helm charts update

### DIFF
--- a/pkg/reconciler/instances/eventing/preaction/handlejsupdate.go
+++ b/pkg/reconciler/instances/eventing/preaction/handlejsupdate.go
@@ -1,0 +1,87 @@
+package preaction
+
+import (
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/instances/eventing/log"
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/kubernetes/progress"
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/service"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strings"
+)
+
+const (
+	handleJsUpdateName = "handleToggleJSFileStorage"
+	serverNameEnv      = "SERVER_NAME"
+)
+
+type handleJsUpdate struct {
+	kubeClientProvider
+}
+
+// newHandleEnableJSFileStorage
+func newHandleJsUpdate() *handleJsUpdate {
+	return &handleJsUpdate{
+		kubeClientProvider: defaultKubeClientProvider,
+	}
+}
+
+func (r *handleJsUpdate) Execute(context *service.ActionContext, logger *zap.SugaredLogger) error {
+	// decorate logger
+	logger = logger.With(log.KeyStep, handleJsUpdateName)
+
+	kubeClient, err := r.kubeClientProvider(context, logger)
+	if err != nil {
+		return err
+	}
+
+	clientSet, err := kubeClient.Clientset()
+	if err != nil {
+		return err
+	}
+
+	statefulSet, err := clientSet.AppsV1().StatefulSets(namespace).Get(context.Context, statefulSetName, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			logger.With(log.KeyReason, "Nats StatefulSet not found").Info("Step skipped")
+			return nil
+		}
+		return err
+	}
+
+	tracker, err := progress.NewProgressTracker(clientSet, logger, progress.Config{Interval: progressTrackerInterval, Timeout: progressTrackerTimeout})
+	if err != nil {
+		return err
+	}
+
+	serverNameExists, err := envVarExist(statefulSet, serverNameEnv)
+	if err != nil {
+		return err
+	}
+
+	// Updating the NATS Helm charts to the version 0.17.3 requires some changes in the StatefulSet's Spec.
+	// This requires a deletion of the StatefulSet.
+	// The SERVER_NAME Env variable can be considered as an indicator for the update. The previous Kyma NATS chart versions didn't have it.
+	if !serverNameExists {
+		if err := deleteNatsStatefulSet(context, clientSet, tracker, logger, statefulSet, false); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	logger.With(log.KeyReason, "No actions needed").Info("Step skipped")
+	return nil
+}
+
+// envVarExist checks whether a StatefulSet contains an env variable or not.
+func envVarExist(statefulSet *appsv1.StatefulSet, envName string) (bool, error) {
+	for _, container := range statefulSet.Spec.Template.Spec.Containers {
+		for _, env := range container.Env {
+			if strings.EqualFold(env.Name, envName) {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}

--- a/pkg/reconciler/instances/eventing/preaction/handlejsupdate.go
+++ b/pkg/reconciler/instances/eventing/preaction/handlejsupdate.go
@@ -55,10 +55,7 @@ func (r *handleJsUpdate) Execute(context *service.ActionContext, logger *zap.Sug
 		return err
 	}
 
-	serverNameExists, err := envVarExist(statefulSet, serverNameEnv)
-	if err != nil {
-		return err
-	}
+	serverNameExists := envVarExist(statefulSet, serverNameEnv)
 
 	// Updating the NATS Helm charts to the version 0.17.3 requires some changes in the StatefulSet's Spec.
 	// This requires a deletion of the StatefulSet.
@@ -75,13 +72,13 @@ func (r *handleJsUpdate) Execute(context *service.ActionContext, logger *zap.Sug
 }
 
 // envVarExist checks whether a StatefulSet contains an env variable or not.
-func envVarExist(statefulSet *appsv1.StatefulSet, envName string) (bool, error) {
+func envVarExist(statefulSet *appsv1.StatefulSet, envName string) bool {
 	for _, container := range statefulSet.Spec.Template.Spec.Containers {
 		for _, env := range container.Env {
 			if strings.EqualFold(env.Name, envName) {
-				return true, nil
+				return true
 			}
 		}
 	}
-	return false, nil
+	return false
 }

--- a/pkg/reconciler/instances/eventing/preaction/handlejsupdate.go
+++ b/pkg/reconciler/instances/eventing/preaction/handlejsupdate.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	handleJsUpdateName = "handleToggleJSFileStorage"
+	handleJsUpdateName = "handleNatsHelmChartsUpdate"
 	serverNameEnv      = "SERVER_NAME"
 )
 
@@ -20,7 +20,7 @@ type handleJsUpdate struct {
 	kubeClientProvider
 }
 
-// newHandleEnableJSFileStorage
+// handleJsUpdate
 func newHandleJsUpdate() *handleJsUpdate {
 	return &handleJsUpdate{
 		kubeClientProvider: defaultKubeClientProvider,

--- a/pkg/reconciler/instances/eventing/preaction/handlejsupdate_test.go
+++ b/pkg/reconciler/instances/eventing/preaction/handlejsupdate_test.go
@@ -1,0 +1,97 @@
+package preaction
+
+import (
+	"context"
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/instances/eventing/log"
+	k8s "github.com/kyma-incubator/reconciler/pkg/reconciler/kubernetes"
+	"github.com/stretchr/testify/mock"
+	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"testing"
+
+	chartmocks "github.com/kyma-incubator/reconciler/pkg/reconciler/chart/mocks"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kyma-incubator/reconciler/pkg/logger"
+	"github.com/kyma-incubator/reconciler/pkg/reconciler"
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/kubernetes/mocks"
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/service"
+)
+
+func TestJsUpdate(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		givenStatefulSet        *appsv1.StatefulSet
+		wantStatefulSetDeletion bool
+	}{
+		{
+			name:                    "Should delete the StatefulSet if the SERVER_NAME env variable is not present",
+			givenStatefulSet:        newStatefulSet(),
+			wantStatefulSetDeletion: true,
+		},
+		{
+			name:                    "Should do nothing if the SERVER_NAME env variable is present",
+			givenStatefulSet:        newStatefulSet(withEnvVar(v1.EnvVar{Name: serverNameEnv, Value: "true"})),
+			wantStatefulSetDeletion: false,
+		},
+	}
+
+	setup := func(t *testing.T) (kubernetes.Interface, handleJsUpdate, *service.ActionContext) {
+		k8sClient := fake.NewSimpleClientset()
+		mockClient := mocks.Client{}
+		mockClient.On("Clientset").Return(k8sClient, nil)
+		action := handleJsUpdate{
+			kubeClientProvider: func(context *service.ActionContext, logger *zap.SugaredLogger) (k8s.Client, error) {
+				return &mockClient, nil
+			},
+		}
+
+		chartProvider := &chartmocks.Provider{}
+		chartValuesYAML := getJetstreamValuesYAML(true, fileStorageType)
+		chartValues, err := unmarshalTestValues(chartValuesYAML)
+		require.NoError(t, err)
+
+		chartProvider.On("Configuration", mock.Anything).Return(chartValues, nil)
+
+		actionContext := &service.ActionContext{
+			KubeClient:    &mockClient,
+			Context:       context.TODO(),
+			Logger:        logger.NewLogger(false),
+			Task:          &reconciler.Task{Version: "test"},
+			ChartProvider: chartProvider,
+		}
+		return k8sClient, action, actionContext
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// given
+			var err error
+			k8sClient, action, actionContext := setup(t)
+
+			_, err = createStatefulSet(actionContext.Context, k8sClient, tc.givenStatefulSet)
+			require.NoError(t, err)
+
+			// when
+			err = action.Execute(actionContext, log.ContextLogger(actionContext, log.WithAction(actionName)))
+			require.NoError(t, err)
+
+			// then
+			gotStatefulSet, err := k8sClient.AppsV1().StatefulSets(namespace).Get(actionContext.Context, statefulSetName, metav1.GetOptions{})
+			if !k8serrors.IsNotFound(err) {
+				require.NoError(t, err)
+			}
+			if tc.wantStatefulSetDeletion {
+				require.Nil(t, gotStatefulSet)
+			} else {
+				require.NotNil(t, gotStatefulSet)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/instances/eventing/preaction/handletogglejsfilestorage.go
+++ b/pkg/reconciler/instances/eventing/preaction/handletogglejsfilestorage.go
@@ -151,7 +151,7 @@ func deleteNatsStatefulSet(context *service.ActionContext, clientSet k8s.Interfa
 	if err := addToProgressTracker(tracker, logger, statefulSetType, statefulSetName); err != nil {
 		return err
 	}
-	logger.Info("Deleting nats StatefulSet in order to perform the PVC migration")
+	logger.Info("Deleting nats StatefulSet in order to perform the migration")
 	if err := clientSet.AppsV1().StatefulSets(namespace).Delete(context.Context, statefulSetName, metav1.DeleteOptions{}); err != nil {
 		return err
 	}

--- a/pkg/reconciler/instances/eventing/preaction/handletogglejsfilestorage_test.go
+++ b/pkg/reconciler/instances/eventing/preaction/handletogglejsfilestorage_test.go
@@ -131,7 +131,7 @@ func TestToggleJsFileStoragePreAction(t *testing.T) {
 		}
 
 		chartProvider := &chartmocks.Provider{}
-		chartValuesYAML := getJestreamValuesYAML(jsEnabled, storageType)
+		chartValuesYAML := getJetstreamValuesYAML(jsEnabled, storageType)
 		chartValues, err := unmarshalTestValues(chartValuesYAML)
 		require.NoError(t, err)
 
@@ -221,6 +221,16 @@ func withReplicas(replicas int) statefulSetOpt {
 	}
 }
 
+func withEnvVar(envVar v1.EnvVar) statefulSetOpt {
+	return func(statefulSet *appsv1.StatefulSet) {
+		statefulSet.Spec.Template.Spec.Containers = []v1.Container{
+			{
+				Env: []v1.EnvVar{envVar},
+			},
+		}
+	}
+}
+
 func withVolumeClaimTemplates() statefulSetOpt {
 	return func(statefulSet *appsv1.StatefulSet) {
 		var persistentVolumeClaims []v1.PersistentVolumeClaim
@@ -235,7 +245,7 @@ func withVolumeClaimTemplates() statefulSetOpt {
 	}
 }
 
-func getJestreamValuesYAML(jsEnabled bool, fileStorage string) string {
+func getJetstreamValuesYAML(jsEnabled bool, fileStorage string) string {
 	return fmt.Sprintf(`
     global:
       jetstream:

--- a/pkg/reconciler/instances/eventing/preaction/preaction.go
+++ b/pkg/reconciler/instances/eventing/preaction/preaction.go
@@ -13,5 +13,6 @@ func New() *action.Action {
 	return action.New(actionName, action.Steps{
 		// add PreAction steps here
 		newHandleToggleJSFileStorage(),
+		newHandleJsUpdate(),
 	})
 }


### PR DESCRIPTION
**Changes in this Pull Request**

- `SERVER_NAME` env var could act as an indicator for updating the NATS helm charts from existing version to the latest `0.17.3` version
- the changes in the charts touch the StatefulSet Spec, which requires the recreation of the STS
- the PVC stays untouched, which means: `no messages in the stream will be lost, in case there are any`

**Related Issue**
https://github.com/kyma-project/kyma/issues/14961