### PR TITLE
breaking change: upgrade to go 1.19 - Protecode vulnerabilities

### DIFF
--- a/Dockerfile.cr
+++ b/Dockerfile.cr
@@ -4,7 +4,7 @@ FROM eu.gcr.io/kyma-project/external/istio/istioctl:1.13.2 AS istio-1_13_2
 FROM eu.gcr.io/kyma-project/external/istio/istioctl:1.14.1 AS istio-1_14_1
 
 # Build image
-FROM golang:1.18.1-alpine3.15 AS build
+FROM golang:1.19.0-alpine3.16 AS build
 
 ENV SRC_DIR=/go/src/github.com/kyma-incubator/reconciler
 COPY . $SRC_DIR

--- a/Dockerfile.mr
+++ b/Dockerfile.mr
@@ -1,5 +1,5 @@
 # Build image
-FROM golang:1.18.1-alpine3.15 AS build
+FROM golang:1.19.0-alpine3.16 AS build
 
 ENV SRC_DIR=/go/src/github.com/kyma-incubator/reconciler
 COPY . $SRC_DIR

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-incubator/reconciler
 
-go 1.17
+go 1.19
 
 replace (
 	//fix for CVE-2022-24778


### PR DESCRIPTION
This should solve all protecode security vulnerabilities associated with golang versions 1.17.x and 1.18.x