### PR TITLE
Remove unsupported Istio versions from reconciler

### DIFF
--- a/Dockerfile.cr
+++ b/Dockerfile.cr
@@ -1,6 +1,4 @@
 # Istioctl source images
-FROM eu.gcr.io/kyma-project/external/istio/istioctl:1.12.3 AS istio-1_12_3
-FROM eu.gcr.io/kyma-project/external/istio/istioctl:1.13.2 AS istio-1_13_2
 FROM eu.gcr.io/kyma-project/external/istio/istioctl:1.14.3 AS istio-1_14_3
 
 # Build image
@@ -38,11 +36,9 @@ COPY --from=build /bin/reconciler /bin/reconciler
 COPY --from=build /configs/ /configs/
 
 # Add istioctl tools
-COPY --from=istio-1_12_3 /usr/local/bin/istioctl /bin/istioctl-1.12.3
-COPY --from=istio-1_13_2 /usr/local/bin/istioctl /bin/istioctl-1.13.2
 COPY --from=istio-1_14_3 /usr/local/bin/istioctl /bin/istioctl-1.14.3
 # For multiple istioctl binaries, provide their paths separated with a semicolon (;) like in the Linux PATH variable.
-ENV ISTIOCTL_PATH=/bin/istioctl-1.12.3;/bin/istioctl-1.13.2;/bin/istioctl-1.14.3
+ENV ISTIOCTL_PATH=/bin/istioctl-1.14.3
 
 USER appuser:appuser
 


### PR DESCRIPTION
Both 1.12 and 1.13 aren't supported anymore