### PR TITLE
Support RmiVmalertGroupsNum for VMAlert scaled out

### DIFF
--- a/pkg/reconciler/instances/rma/integration_action.go
+++ b/pkg/reconciler/instances/rma/integration_action.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"net/http"
 	"regexp"
+	"strconv"
 	"sync"
 	"time"
 
@@ -24,12 +25,15 @@ import (
 )
 
 const (
-	RmiHelmDriver      = "secret"
-	RmiHelmMaxHistory  = 1
-	RmiChartName       = "rmi"
-	RmiChartURLConfig  = "rmi.chartUrl"
-	RmiNamespaceConfig = "rmi.namespace"
+	RmiHelmDriver       = "secret"
+	RmiHelmMaxHistory   = 1
+	RmiChartName        = "rmi"
+	RmiChartURLConfig   = "rmi.chartUrl"
+	RmiNamespaceConfig  = "rmi.namespace"
+	RmiVmalertGroupsNum = "rmi.vmalertGroupsNum"
 )
+
+const DefaultVMAlertGroupsNum = 1
 
 type IntegrationAction struct {
 	name         string
@@ -67,6 +71,11 @@ func (a *IntegrationAction) Run(context *service.ActionContext) error {
 		context.Logger.Error(err)
 		return err
 	}
+	groupsNum := getConfigString(context.Task.Configuration, RmiVmalertGroupsNum)
+	if groupsNum == "" {
+		context.Logger.Debugf("missing configuration: %s, will use its default value: %d", RmiVmalertGroupsNum, DefaultVMAlertGroupsNum)
+	}
+
 	releaseName := context.Task.Metadata.ShootName
 
 	cfg, err := a.client.HelmActionConfiguration(namespace)
@@ -92,7 +101,7 @@ func (a *IntegrationAction) Run(context *service.ActionContext) error {
 
 		// If a release does not exist, run helm install
 		if err == driver.ErrReleaseNotFound {
-			return a.install(context, cfg, chartURL, releaseName, namespace)
+			return a.install(context, cfg, chartURL, releaseName, namespace, groupsNum)
 		}
 
 		// If the release exists, only run helm upgrade if the integration chart version is different.
@@ -114,7 +123,7 @@ func (a *IntegrationAction) Run(context *service.ActionContext) error {
 			context.Logger.Infof("%s-%s target version: %s release version/status: %s/%s, starting upgrade.", RmiChartName, releaseName, upgradeVersion, releaseVersion, helmRelease.Info.Status)
 		}
 
-		return a.upgrade(context, cfg, chartURL, releaseName, namespace, skipHelmUpgrade)
+		return a.upgrade(context, cfg, chartURL, releaseName, namespace, groupsNum, skipHelmUpgrade)
 	case model.OperationTypeDelete:
 		if err == nil {
 			return a.delete(cfg, releaseName)
@@ -124,7 +133,7 @@ func (a *IntegrationAction) Run(context *service.ActionContext) error {
 	return nil
 }
 
-func (a *IntegrationAction) install(context *service.ActionContext, cfg *action.Configuration, chartURL, releaseName, namespace string) error {
+func (a *IntegrationAction) install(context *service.ActionContext, cfg *action.Configuration, chartURL, releaseName, namespace, groupsNum string) error {
 	installAction := action.NewInstall(cfg)
 	installAction.ReleaseName = releaseName
 	installAction.Namespace = namespace
@@ -139,7 +148,7 @@ func (a *IntegrationAction) install(context *service.ActionContext, cfg *action.
 	if err != nil {
 		return errors.Wrap(err, "while generating new auth password")
 	}
-	overrides := generateOverrideMap(context, username, password)
+	overrides := generateOverrideMap(context, username, password, groupsNum)
 
 	_, err = installAction.Run(chart, overrides)
 	if err != nil {
@@ -150,7 +159,7 @@ func (a *IntegrationAction) install(context *service.ActionContext, cfg *action.
 	return nil
 }
 
-func (a *IntegrationAction) upgrade(context *service.ActionContext, cfg *action.Configuration, chartURL, releaseName, namespace string, skipHelmUpgrade bool) error {
+func (a *IntegrationAction) upgrade(context *service.ActionContext, cfg *action.Configuration, chartURL, releaseName, namespace, groupsNum string, skipHelmUpgrade bool) error {
 	username := context.Task.Metadata.InstanceID
 	password, err := a.fetchPassword(context.Context, releaseName, namespace)
 	if err != nil {
@@ -173,7 +182,7 @@ func (a *IntegrationAction) upgrade(context *service.ActionContext, cfg *action.
 		return errors.Wrapf(err, "while fetching rmi chart from %s", chartURL)
 	}
 
-	overrides := generateOverrideMap(context, username, password)
+	overrides := generateOverrideMap(context, username, password, groupsNum)
 
 	_, err = upgradeAction.Run(releaseName, chart, overrides)
 	if err != nil {
@@ -273,7 +282,7 @@ func (a *IntegrationAction) getChartVersionFromURL(chartURL string) string {
 	return match[1]
 }
 
-func generateOverrideMap(context *service.ActionContext, username, password string) map[string]interface{} {
+func generateOverrideMap(context *service.ActionContext, username, password, groupsNum string) map[string]interface{} {
 	overrideMap := make(map[string]interface{})
 	metadata := context.Task.Metadata
 	overrideMap["runtime"] = map[string]string{
@@ -287,6 +296,9 @@ func generateOverrideMap(context *service.ActionContext, username, password stri
 	overrideMap["auth"] = map[string]string{
 		"username": username,
 		"password": password,
+	}
+	overrideMap["vmalert"] = map[string]int{
+		"group": generateVmalertGroup(context, metadata.InstanceID, groupsNum),
 	}
 
 	return overrideMap
@@ -321,4 +333,19 @@ func findLatestRevision(releases []*release.Release) *release.Release {
 	}
 
 	return release
+}
+
+func generateVmalertGroup(context *service.ActionContext, id, num string) int {
+	div := DefaultVMAlertGroupsNum
+
+	if num != "" && id != "" {
+		var err error
+		div, err = strconv.Atoi(num)
+		if err != nil {
+			context.Logger.Debugf("got error %s when converting string to int for configuration: %s, use its default value: %d", err, RmiVmalertGroupsNum, DefaultVMAlertGroupsNum)
+			div = DefaultVMAlertGroupsNum
+		}
+	}
+
+	return int(id[0]) % div
 }

--- a/pkg/reconciler/instances/rma/integration_action_test.go
+++ b/pkg/reconciler/instances/rma/integration_action_test.go
@@ -63,6 +63,20 @@ func Test_IntegrationAction_Run(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("should pass when rmi.vmalertGroupsNum config is missing", func(t *testing.T) {
+		// given
+		action := NewIntegrationAction("test", testClient)
+		server := fixChartHTTPServer(t, testChart)
+		context := fixActionContext(fixChartURL(server.URL))
+		delete(context.Task.Configuration, RmiVmalertGroupsNum)
+
+		// when
+		err := action.Run(context)
+
+		// then
+		require.NoError(t, err)
+	})
+
 	t.Run("should install rmi when release not found", func(t *testing.T) {
 		// given
 		action := NewIntegrationAction("test", testClient)
@@ -171,8 +185,9 @@ func fixActionContext(chartURL string) *service.ActionContext {
 		Version:   "2.0.0",
 		Profile:   "production",
 		Configuration: map[string]interface{}{
-			RmiNamespaceConfig: "monitoring-system",
-			RmiChartURLConfig:  chartURL,
+			RmiNamespaceConfig:  "monitoring-system",
+			RmiChartURLConfig:   chartURL,
+			RmiVmalertGroupsNum: "6",
 		},
 		Metadata: keb.Metadata{
 			GlobalAccountID: "testGA",
@@ -202,7 +217,6 @@ func fixChartArchive(t *testing.T) []byte {
 	buf := bytes.Buffer{}
 	err := compress("./testdata", &buf)
 	require.NoError(t, err)
-
 	return buf.Bytes()
 }
 

--- a/pkg/reconciler/instances/rma/testdata/values.yaml
+++ b/pkg/reconciler/instances/rma/testdata/values.yaml
@@ -8,3 +8,5 @@ runtime:
 auth:
   username: ""
   password: ""
+vmalert:
+  group: 0

--- a/scripts/.golangci.yml
+++ b/scripts/.golangci.yml
@@ -9,3 +9,6 @@ issues:
     - path: 'mothership_integration_test.go'
       linters:
         - unused
+    - text: "G404:" # Ignore weak random number generator lint. We do not need strong randomness here.
+      linters:
+        - gosec


### PR DESCRIPTION
## Description

As per this [backlog](https://github.tools.sap/kyma/backlog/issues/2864), this is to add the support to scale out the VMAlert number. The tag for the processing runtime VMRule will be set to `vmalert-group: skr-{n}`. n is between [0, rmi.vmalertGroupsNum). Then the vmrule will be distributed to the corresponding vmalert object.