### PR TITLE
Rename Istio CNI ConfigMap key

### DIFF
--- a/pkg/reconciler/instances/istio/actions/performer_test.go
+++ b/pkg/reconciler/instances/istio/actions/performer_test.go
@@ -497,7 +497,7 @@ func Test_DefaultIstioPerformer_CNI_Merge(t *testing.T) {
 				Namespace: "kyma-system",
 			},
 			Data: map[string]string{
-				"enabled": "true",
+				"cniEnabled": "true",
 			},
 		}
 		client := fake.NewSimpleClientset(cm)
@@ -530,7 +530,7 @@ func Test_DefaultIstioPerformer_CNI_Merge(t *testing.T) {
 				Namespace: "kyma-system",
 			},
 			Data: map[string]string{
-				"enabled": "true",
+				"cniEnabled": "true",
 			},
 		}
 		client := fake.NewSimpleClientset(cm)

--- a/pkg/reconciler/instances/istio/cni/cni.go
+++ b/pkg/reconciler/instances/istio/cni/cni.go
@@ -20,6 +20,7 @@ import (
 const (
 	kymaNamespace     = "kyma-system"
 	configMapCNI      = "kyma-istio-cni"
+	configMapCNIKey   = "cniEnabled"
 	istioOperatorName = "installed-state-default-operator"
 	istioNamespace    = "istio-system"
 )
@@ -71,7 +72,7 @@ func getCNIConfigMapValue(ctx context.Context, clientSet kubernetes.Interface) (
 		return "", err
 	}
 
-	cniEnabled, ok := cm.Data["enabled"]
+	cniEnabled, ok := cm.Data[configMapCNIKey]
 	if !ok {
 		return "", nil
 	}

--- a/pkg/reconciler/instances/istio/cni/cni_test.go
+++ b/pkg/reconciler/instances/istio/cni/cni_test.go
@@ -63,7 +63,7 @@ func Test_ApplyCNIConfiguration(t *testing.T) {
 			Name:      configMapCNI,
 			Namespace: kymaNamespace,
 		},
-			Data: map[string]string{"enabled": configMapValueString},
+			Data: map[string]string{configMapCNIKey: configMapValueString},
 		}
 		client := k8sClientFake.NewSimpleClientset(istioCNIConfigMap)
 		provider := &clientsetmocks.Provider{}
@@ -106,7 +106,7 @@ func Test_ApplyCNIConfiguration(t *testing.T) {
 			Name:      configMapCNI,
 			Namespace: kymaNamespace,
 		},
-			Data: map[string]string{"enabled": configMapValueString},
+			Data: map[string]string{configMapCNIKey: configMapValueString},
 		}
 		client := k8sClientFake.NewSimpleClientset(istioCNIConfigMap)
 		provider := &clientsetmocks.Provider{}


### PR DESCRIPTION
Renaming ConfigMap key to improve readability.
- https://github.com/kyma-incubator/reconciler/issues/1243