### PR TITLE
add label for signify operator to kyma-system namespace

### DIFF
--- a/pkg/reconciler/service/nsinterceptor.go
+++ b/pkg/reconciler/service/nsinterceptor.go
@@ -6,8 +6,9 @@ import (
 )
 
 const (
-	NameLabel             = "name"
-	SidecarInjectionLabel = "istio-injection"
+	NameLabel              = "name"
+	SidecarInjectionLabel  = "istio-injection"
+	SignifyValidationLabel = "namespaces.warden.kyma-project.io/validate"
 )
 
 type NamespaceInterceptor struct {
@@ -22,6 +23,12 @@ func (l *NamespaceInterceptor) Intercept(resources *kubernetes.ResourceCacheList
 		}
 		labels[NameLabel] = u.GetName()
 		labels[SidecarInjectionLabel] = "enabled"
+
+		//enable Signify signature validation for kyma-system namespace
+		if u.GetName() == "kyma-system" {
+			labels[SignifyValidationLabel] = "enabled"
+		}
+
 		u.SetLabels(labels)
 		return nil
 	}

--- a/pkg/reconciler/service/nsinterceptor_test.go
+++ b/pkg/reconciler/service/nsinterceptor_test.go
@@ -50,6 +50,27 @@ func TestNamespaceInterceptor(t *testing.T) {
 				NameLabel:             "namespace2",
 			},
 		},
+		{
+			name: "Namespace kyma-system with labels",
+			resource: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Namespace",
+					"metadata": map[string]interface{}{
+						"name": "kyma-system",
+						"labels": map[string]interface{}{
+							"some-label": "some-value",
+						},
+					},
+				},
+			},
+			expectedLabels: map[string]string{
+				SidecarInjectionLabel:  "enabled",
+				"some-label":           "some-value",
+				NameLabel:              "kyma-system",
+				SignifyValidationLabel: "enabled",
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt


### PR DESCRIPTION
**Description**
Required by Signify operator (warden) to scan pods within the `kyma-system` namespace.