### PR TITLE
Fix RMA reconciler nil pointer error

### DIFF
--- a/pkg/reconciler/instances/rma/integration_action.go
+++ b/pkg/reconciler/instances/rma/integration_action.go
@@ -85,6 +85,9 @@ func (a *IntegrationAction) Run(context *service.ActionContext) error {
 	if err != nil {
 		return err
 	}
+	if cfg == nil {
+		return errors.New("Could not get helm action configuration")
+	}
 
 	histClient := action.NewHistory(cfg)
 	histClient.Max = 1


### PR DESCRIPTION
RMA reconciliation fails sometimes due to the helm action config not being available. Eventually reconciliation succeeds, this is to fix the go panic