### PR TITLE
Sync finalizers for OAuth2Client resources

### DIFF
--- a/pkg/reconciler/service/install.go
+++ b/pkg/reconciler/service/install.go
@@ -64,6 +64,7 @@ func (r *Install) Invoke(ctx context.Context, chartProvider chart.Provider, task
 				interceptableKinds: []string{
 					"LogPipeline",
 					"LogParser",
+					"OAuth2Client",
 				},
 			},
 		)


### PR DESCRIPTION
Fix for issue with colliding updates on Oauth2Client and eventing manifest (see [issue](https://github.tools.sap/kyma/backlog/issues/3227))