### PR TITLE
Removal of the dependencies to kyma-integration Namespace

### DIFF
--- a/pkg/reconciler/instances/cleaner/action.go
+++ b/pkg/reconciler/instances/cleaner/action.go
@@ -33,7 +33,7 @@ func (a *CleanupAction) Run(context *service.ActionContext) error {
 		return err
 	}
 
-	namespaces := []string{"kyma-system", "kyma-integration"}
+	namespaces := []string{"kyma-system"}
 
 	var kymaCRDsFinder cleanup.KymaCRDsFinder = func() ([]schema.GroupVersionResource, error) {
 		crdManifests, err := context.ChartProvider.RenderCRD(context.Task.Version)


### PR DESCRIPTION
**Description**

`kyma-integration` Namespace is no longer in use by Application Connector components.


[Related issue](https://github.com/kyma-project/kyma/issues/15915)