### PR TITLE
Trivial cluster-essentials reconciler

### DIFF
--- a/pkg/reconciler/instances/clusteressentials/action.go
+++ b/pkg/reconciler/instances/clusteressentials/action.go
@@ -1,0 +1,14 @@
+package clusteressentials
+
+import (
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/service"
+)
+
+type CustomAction struct {
+	name string
+}
+
+func (a *CustomAction) Run(context *service.ActionContext) error {
+	context.Logger.Debugf("Action '%s' executed (passed version was '%s')", a.name, context.Task.Version)
+	return service.NewInstall(context.Logger).Invoke(context.Context, context.ChartProvider, context.Task, context.KubeClient)
+}

--- a/pkg/reconciler/instances/clusteressentials/clusteressentials.go
+++ b/pkg/reconciler/instances/clusteressentials/clusteressentials.go
@@ -1,0 +1,24 @@
+package clusteressentials
+
+import (
+	"github.com/kyma-incubator/reconciler/pkg/logger"
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/service"
+)
+
+const ReconcilerName = "cluster-essentials"
+
+//nolint:gochecknoinits //usage of init() is intended to register reconciler-instances in centralized registry
+func init() {
+	log := logger.NewLogger(false)
+
+	log.Debugf("Initializing component reconciler '%s'", ReconcilerName)
+	reconciler, err := service.NewComponentReconciler(ReconcilerName)
+	if err != nil {
+		log.Fatalf("Could not create '%s' component reconciler: %s", ReconcilerName, err)
+	}
+
+	reconciler.
+		WithReconcileAction(&CustomAction{
+			name: "cluster-essentials",
+		})
+}

--- a/pkg/reconciler/instances/loader.go
+++ b/pkg/reconciler/instances/loader.go
@@ -7,6 +7,8 @@ import (
 	_ "github.com/kyma-incubator/reconciler/pkg/reconciler/instances/base"
 	// import required to register component reconciler 'cleaner' in reconciler registry
 	_ "github.com/kyma-incubator/reconciler/pkg/reconciler/instances/cleaner"
+	// import required to register component reconciler 'clusteressentials' in reconciler registry
+	_ "github.com/kyma-incubator/reconciler/pkg/reconciler/instances/clusteressentials"
 	// import required to register component reconciler 'connectivityproxy' in reconciler registry
 	_ "github.com/kyma-incubator/reconciler/pkg/reconciler/instances/connectivityproxy"
 	// import required to register component reconciler 'istio' in reconciler registry


### PR DESCRIPTION
Removal of `PodPreset` and custom cluster-essentials reconciler from https://github.com/kyma-incubator/reconciler/pull/1286/ is more involved and requires additional changes in control-plane https://github.com/kyma-project/control-plane/pull/2454. For the upcoming kyma release, it's decided to be easier to put trivial cluster-essentials reconciler and not use the base reconciler. Code cleanup will follow up.