### PR TITLE
Update integration_action.go, integration_action_test.go, configmap.yaml, values.yaml

### DIFF
--- a/pkg/reconciler/instances/rma/integration_action.go
+++ b/pkg/reconciler/instances/rma/integration_action.go
@@ -319,7 +319,10 @@ func generateOverrideMap(context *service.ActionContext, username, password, gro
 }
 
 func getDomain(host string) string {
-	url, _ := url.Parse(host)
+	url, err := url.Parse(host)
+	if err != nil {
+		return ""
+	}
 	domain := strings.TrimPrefix(url.Hostname(), "api.")
 
 	return domain

--- a/pkg/reconciler/instances/rma/integration_action.go
+++ b/pkg/reconciler/instances/rma/integration_action.go
@@ -11,8 +11,10 @@ import (
 	"math/big"
 	mrand "math/rand"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -291,6 +293,11 @@ func (a *IntegrationAction) getChartVersionFromURL(chartURL string) string {
 func generateOverrideMap(context *service.ActionContext, username, password, groupsNum string) map[string]interface{} {
 	overrideMap := make(map[string]interface{})
 	metadata := context.Task.Metadata
+
+	//Get domain via kubeclient because it is not available in metadata
+	host := context.KubeClient.GetHost()
+	domain := getDomain(host)
+
 	overrideMap["runtime"] = map[string]string{
 		"instanceID":      metadata.InstanceID,
 		"globalAccountID": metadata.GlobalAccountID,
@@ -298,6 +305,7 @@ func generateOverrideMap(context *service.ActionContext, username, password, gro
 		"shootName":       metadata.ShootName,
 		"planName":        metadata.ServicePlanName,
 		"region":          metadata.Region,
+		"dnsDomain":       domain,
 	}
 	overrideMap["auth"] = map[string]string{
 		"username": username,
@@ -308,6 +316,13 @@ func generateOverrideMap(context *service.ActionContext, username, password, gro
 	}
 
 	return overrideMap
+}
+
+func getDomain(host string) string {
+	url, _ := url.Parse(host)
+	domain := strings.TrimPrefix(url.Hostname(), "api.")
+
+	return domain
 }
 
 func getConfigString(config map[string]interface{}, key string) string {

--- a/pkg/reconciler/instances/rma/integration_action_test.go
+++ b/pkg/reconciler/instances/rma/integration_action_test.go
@@ -192,6 +192,8 @@ func fixActionContext(chartURL string) *service.ActionContext {
 
 	mockClient := &mocks.Client{}
 	mockClient.On("DeleteResource", mock.Anything, "deployment", "avs-bridge", "kyma-system").Return(nil, nil)
+	mockClient.On("getDomain").Return("testDomain", nil)
+	mockClient.On("GetHost").Return("tmphost")
 
 	return &service.ActionContext{
 		Context:    context.Background(),
@@ -228,6 +230,7 @@ func assertRMIConfig(t *testing.T, context *service.ActionContext, group int, co
 	assert.Equal(t, context.Task.Metadata.GlobalAccountID, runtime["globalAccountID"])
 	assert.Equal(t, context.Task.Metadata.SubAccountID, runtime["subaccountID"])
 	assert.Equal(t, context.Task.Metadata.ShootName, runtime["shootName"])
+	assert.Equal(t, getDomain(context.Task.Metadata.ShootName), runtime["dnsDomain"])
 	assert.Equal(t, context.Task.Metadata.ServicePlanName, runtime["planName"])
 	assert.Equal(t, context.Task.Metadata.Region, runtime["region"])
 	assert.Equal(t, context.Task.Metadata.InstanceID, auth["username"])

--- a/pkg/reconciler/instances/rma/testdata/templates/configmap.yaml
+++ b/pkg/reconciler/instances/rma/testdata/templates/configmap.yaml
@@ -12,3 +12,4 @@ data:
   shootName: {{ .Values.runtime.shootName }}
   planName: {{ .Values.runtime.planName }}
   region: {{ .Values.runtime.region }}
+  dnsDomain: {{ .Values.runtime.dnsDomain }}

--- a/pkg/reconciler/instances/rma/testdata/values.yaml
+++ b/pkg/reconciler/instances/rma/testdata/values.yaml
@@ -5,6 +5,7 @@ runtime:
   shootName: ""
   planName: ""
   region: ""
+  dnsDomain: ""
 auth:
   username: ""
   password: ""


### PR DESCRIPTION
Related to : https://github.tools.sap/kyma/backlog/issues/3399

Update integration_action.go, integration_action_test.go, configmap.yaml, values.yaml

to have getDomain function which uses kubeclient to get domains as its not available in metadata.