### PR TITLE
Fix Istio cmd test failing for GO 1.20

### DIFF
--- a/pkg/reconciler/instances/istio/istioctl/commander_test.go
+++ b/pkg/reconciler/instances/istio/istioctl/commander_test.go
@@ -121,7 +121,7 @@ func Test_DefaultCommander_Version(t *testing.T) {
 
 		// then
 		require.NoError(t, errors)
-		require.EqualValues(t, versionOutput, string(got))
+		require.Contains(t, string(got), versionOutput)
 		require.EqualValues(t, testArgs[0], "version")
 		require.EqualValues(t, testArgs[2], "json")
 		require.EqualValues(t, testArgs[3], "--kubeconfig")


### PR DESCRIPTION
One tests fails for GO 1.20 when `GOCOVERDIR` is not set. 
With Go 1.20 new capabilities for [reporting codecoverage](https://go.dev/testing/coverage/) was introduced.
If you don't set GOCOVERDIR per default a warning will be logged. 
The implementation of the commander for the Version function returns a value resolved by the CombinedOutput function. That means it will return stdout + stderr. The warning is returned in the stderr and this would fail the assertion in this case.

A pragmatic solution is to simplify the assertion in this case as we will also soon move the reconciler implementation to the module.