### PR TITLE
Remove notexisting linting commands

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -45,8 +45,8 @@ golangci::run_checks() {
   shout "Run golangci-lint checks"
   LINTS=(
     # default golangci-lint lints
-    deadcode errcheck gosimple govet ineffassign staticcheck \
-    structcheck typecheck unused varcheck \
+    errcheck gosimple govet ineffassign staticcheck \
+    typecheck unused \
     # additional lints
     revive gofmt misspell gochecknoinits unparam exportloopref gosec
   )


### PR DESCRIPTION
Fixing linter error:
```
[0016] | Checks: deadcode errcheck gosimple govet ineffassign staticcheck structcheck typecheck unused varcheck revive gofmt misspell gochecknoinits unparam exportloopref gosec
[0076] | level=warning msg="[runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused."
[0076] | level=warning msg="[runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused."
[0076] | level=warning msg="[runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused."
```

Related issue
https://github.com/golangci/golangci-lint/issues/1841