### PR TITLE
Connectivity-proxy reconciler: Adding support for nested JSON in binding credential secret when spec.secretRootKey is set

### DIFF
--- a/pkg/reconciler/instances/connectivityproxy/action.go
+++ b/pkg/reconciler/instances/connectivityproxy/action.go
@@ -54,11 +54,6 @@ func (a *CustomAction) Run(context *service.ActionContext) error {
 			return errors.Wrap(err, "Error while retrieving service binding secret")
 		}
 
-		// TODO rethink binding secret retrieval
-		if bindingSecret == nil {
-			return errors.New("Missing binding secret")
-		}
-
 		// build overrides for credential secret by reading them from btp-operator secret
 		context.Logger.Debug("Populating configs")
 		a.Commands.PopulateConfigs(context, bindingSecret)
@@ -70,6 +65,7 @@ func (a *CustomAction) Run(context *service.ActionContext) error {
 		}
 		context.Logger.Debug("Creating Istio CA cacert secret for Connectivity Proxy")
 		err = a.Commands.CreateCARootSecret(context, caClient)
+
 		if err != nil {
 			return errors.Wrap(err, "error during creatiion of Istio CA cacert secret for Connectivity Proxy")
 		}

--- a/pkg/reconciler/instances/connectivityproxy/action_test.go
+++ b/pkg/reconciler/instances/connectivityproxy/action_test.go
@@ -137,23 +137,6 @@ func TestAction(t *testing.T) {
 		kubeClient.AssertExpectations(t)
 	})
 
-	t.Run("Should return error when binding exists, but secret is not found", func(t *testing.T) {
-		kubeClient, context, action, loader, commands := setupActionTestEnv()
-
-		kubeClient.On("GetHost").Return("test host")
-		kubeClient.On("GetStatefulSet", context.Context, "test-component", "").Return(nil, nil)
-
-		loader.On("FindBindingOperator", context).Return(binding, nil)
-		loader.On("FindSecret", context, binding).Return(nil, nil)
-
-		err := action.Run(context)
-		require.Error(t, err)
-
-		commands.AssertExpectations(t)
-		loader.AssertExpectations(t)
-		kubeClient.AssertExpectations(t)
-	})
-
 	t.Run("Should return error when binding exists, and FindSecret returns error", func(t *testing.T) {
 		kubeClient, context, action, loader, commands := setupActionTestEnv()
 

--- a/pkg/reconciler/instances/connectivityproxy/loader.go
+++ b/pkg/reconciler/instances/connectivityproxy/loader.go
@@ -50,5 +50,11 @@ func (a *K8sLoader) FindSecret(context *service.ActionContext, binding *unstruct
 		namespace = "default"
 	}
 
-	return context.KubeClient.GetSecret(context.Context, name, namespace)
+	secret, err := context.KubeClient.GetSecret(context.Context, name, namespace)
+
+	if secret == nil {
+		return nil, errors.New("Missing binding secret")
+	}
+
+	return secret, err
 }


### PR DESCRIPTION
Code change allows to parse any nested string value as JSON and extract credential keys and values from it. 

When .spec.secretRootKey is set in connectivity binding the BTP operator generates binding credential secret in different format. All credential information is written into single JSON string under the key `connectivity-proxy-service-key`.

Old secret format:

```
apiVersion: v1
items:
- apiVersion: v1
  data:
    value1: <secret value>
    value2: <secret value>
```

```
apiVersion: v1
items:
- apiVersion: v1
  data:
    connectivity-proxy-service-key:  <secret value>
```

Where <secret value> contains full credential JSON string, where some fiels may contain nested JSON struct like:

`{"key-1": "value-1",  "key-2": "{\"key-3\":\"value-3\", \"key-4\":\"value-4\"}" } `
 
