### PR TITLE
Do not return reconciliation error if binding secret is missing

### DIFF
--- a/pkg/reconciler/instances/connectivityproxy/action.go
+++ b/pkg/reconciler/instances/connectivityproxy/action.go
@@ -50,8 +50,10 @@ func (a *CustomAction) Run(context *service.ActionContext) error {
 		bindingSecret, err := a.Loader.FindSecret(context, binding)
 
 		context.Logger.Debug("Service Binding Secret check")
-		if err != nil {
-			return errors.Wrap(err, "Error while retrieving service binding secret")
+
+		if bindingSecret == nil {
+			context.Logger.Warnf("Skipping reconcilion, %s", err)
+			return nil
 		}
 
 		// build overrides for credential secret by reading them from btp-operator secret

--- a/pkg/reconciler/instances/connectivityproxy/action_test.go
+++ b/pkg/reconciler/instances/connectivityproxy/action_test.go
@@ -137,7 +137,7 @@ func TestAction(t *testing.T) {
 		kubeClient.AssertExpectations(t)
 	})
 
-	t.Run("Should return error when binding exists, and FindSecret returns error", func(t *testing.T) {
+	t.Run("Should ignore error when binding exists, and FindSecret returns error", func(t *testing.T) {
 		kubeClient, context, action, loader, commands := setupActionTestEnv()
 
 		kubeClient.On("GetHost").Return("test host")
@@ -147,7 +147,7 @@ func TestAction(t *testing.T) {
 		loader.On("FindSecret", context, binding).Return(nil, errors.New("some error"))
 
 		err := action.Run(context)
-		require.Error(t, err)
+		require.NoError(t, err)
 
 		commands.AssertExpectations(t)
 		loader.AssertExpectations(t)

--- a/pkg/reconciler/instances/connectivityproxy/loader.go
+++ b/pkg/reconciler/instances/connectivityproxy/loader.go
@@ -41,7 +41,7 @@ func (a *K8sLoader) FindSecret(context *service.ActionContext, binding *unstruct
 
 	name, err := bindingUns.getSecretName()
 	if err != nil {
-		return nil, errors.Wrap(err, "Error while extracting secret")
+		return nil, errors.Wrap(err, "Error while extracting binding secret name")
 	}
 
 	namespace := binding.GetNamespace()


### PR DESCRIPTION
When user did not configured `connectivity-proxy` service plan for its subaccount the `btp-operator` cannot create source binding secret with credentials for connectivity-proxy and the binding remains in the blocked state. 
Such situation was reported as a reconciliation error.

After discussion with SRE team we decided to treat such situation when there is no binding secret as lack of binding. 
Connectivity Proxy Reconciler would not return error in that case, just log a warning. 