### PR TITLE
Update CODEOWNERS for connectivity-proxy

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,7 +14,7 @@
 /pkg/reconciler/instances/serverless/ @m00g3n @pPrecel @dbadura @kwiatekus
 
 # Connectivity Proxy reconciler
-/pkg/reconciler/instances/connectivityproxy/ @akgalwas @koala7659 @ralikio
+/pkg/reconciler/instances/connectivityproxy/ @kyma-incubator/framefrog
 
 # Runtime Monitoring Agent (rma) reconciler
 /pkg/reconciler/instances/rma/ @ebensom @life0215 @lumi017 @tobiscr


### PR DESCRIPTION
Update CODEOWNERS for `connectivity-proxy` component to point to the `framefrog` team instead of a list of individual developers.