### PR TITLE
Remove istioctl 1.16.3 from Reconciler image

### DIFF
--- a/Dockerfile.cr
+++ b/Dockerfile.cr
@@ -1,5 +1,4 @@
 # Istioctl source images
-FROM eu.gcr.io/kyma-project/external/istio/istioctl:1.16.3 AS istio-1_16_3
 FROM europe-docker.pkg.dev/kyma-project/prod/external/istio/istioctl:1.17.2 AS istio-1_17_2
 
 # Build image
@@ -39,10 +38,9 @@ COPY --from=build /bin/reconciler /bin/reconciler
 COPY --from=build /configs/ /configs/
 
 # Add istioctl tools
-COPY --from=istio-1_16_3 /usr/local/bin/istioctl /bin/istioctl-1.16.3
 COPY --from=istio-1_17_2 /usr/local/bin/istioctl /bin/istioctl-1.17.2
 # For multiple istioctl binaries, provide their paths separated with a semicolon (;) like in the Linux PATH variable.
-ENV ISTIOCTL_PATH=/bin/istioctl-1.16.3;/bin/istioctl-1.17.2
+ENV ISTIOCTL_PATH=/bin/istioctl-1.17.2
 
 USER appuser:appuser
 


### PR DESCRIPTION
* Removes istioctl client library for Istio 1.16.3
* We use Istio 1.17.2 on production
* Solves CVEs for golang 1.19.6