### PR TITLE
Fix for loadbalancer detection for empty node port

### DIFF
--- a/pkg/reconciler/instances/serverless/nodeport.go
+++ b/pkg/reconciler/instances/serverless/nodeport.go
@@ -138,6 +138,14 @@ func getAllNodePortServices(ctx context.Context, k8sClient kubernetes.Interface)
 		if svc.Spec.Type == corev1.ServiceTypeNodePort {
 			nodePortSvcs.Items = append(nodePortSvcs.Items, svc)
 		}
+		if svc.Spec.Type == corev1.ServiceTypeLoadBalancer {
+			for _, port := range svc.Spec.Ports {
+				if port.NodePort != 0 {
+					nodePortSvcs.Items = append(nodePortSvcs.Items, svc)
+					break
+				}
+			}
+		}
 	}
 	return nodePortSvcs, nil
 }


### PR DESCRIPTION
When searching for empty node port, reconciler ommited `LoadBalancers` which can also allocate ports.