### PR TITLE
Bump build image versions (Security fix)

### DIFF
--- a/Dockerfile.cr
+++ b/Dockerfile.cr
@@ -3,7 +3,7 @@ FROM europe-docker.pkg.dev/kyma-project/prod/external/istio/istioctl:1.17.3 AS i
 FROM europe-docker.pkg.dev/kyma-project/prod/external/istio/istioctl:1.18.0 AS istio-1_18_0
 
 # Build image
-FROM golang:1.20.4-alpine3.17 AS build
+FROM golang:1.20.5-alpine3.17 AS build
 
 ENV SRC_DIR=/go/src/github.com/kyma-incubator/reconciler
 COPY . $SRC_DIR

--- a/Dockerfile.mr
+++ b/Dockerfile.mr
@@ -1,5 +1,5 @@
 # Build image
-FROM golang:1.20.4-alpine3.17 AS build
+FROM golang:1.20.5-alpine3.17 AS build
 
 ENV SRC_DIR=/go/src/github.com/kyma-incubator/reconciler
 COPY . $SRC_DIR


### PR DESCRIPTION
Bump images used to build component and mothership reconciler binaries from `golang:1.20.4-alpine3.17` to `golang:1.20.5-alpine3.17`
