### PR TITLE
Remove api prefix from the tunnel's URL

### DIFF
--- a/pkg/reconciler/instances/connectivityproxy/action.go
+++ b/pkg/reconciler/instances/connectivityproxy/action.go
@@ -154,6 +154,13 @@ func (a *CustomAction) Run(context *service.ActionContext) error {
 	return nil
 }
 
+func getTunnelURL(actionCtx *service.ActionContext) string {
+	xtHost := actionCtx.Task.Configuration[tagHost].(string)
+	xtHost = strings.TrimPrefix(xtHost, "api.")
+
+	return fmt.Sprintf("cp.%s", xtHost)
+}
+
 // After the Connectivity Proxy was upgraded to 2.9.2 we must fix the configuration mismatch. After the upgrade the configuration will contain incorrect tunnel's URL (it will start with cc-proxy, not cp as expected)
 // As the configuration config map is not applied if it exists (reconciler.kyma-project.io/skip-rendering-on-upgrade annotation), we must update the URL.
 // There is no need to perform the fix, if the version installed on the environment is other that 2.9.2
@@ -166,7 +173,7 @@ func (a *CustomAction) fixConfigurationIfNeeded(context *service.ActionContext) 
 	labels := app.GetLabels()
 	if labels != nil && labels[versionKey] == versionToApplyConfigurationFix {
 		context.Logger.Warn("Fixing Connectivity Proxy configuration...")
-		return a.Commands.FixConfiguration(context, kymaSystem, configurationConfigMap)
+		return a.Commands.FixConfiguration(context, kymaSystem, configurationConfigMap, getTunnelURL(context))
 	}
 
 	return nil
@@ -252,9 +259,7 @@ func prepareOverrides(actionCtx *service.ActionContext, secret *v1.Secret, caDat
 		return err
 	}
 
-	xtHost := actionCtx.Task.Configuration[tagHost].(string)
-
-	actionCtx.Task.Configuration["config.servers.businessDataTunnel.externalHost"] = fmt.Sprintf("cp.%s", xtHost)
+	actionCtx.Task.Configuration["config.servers.businessDataTunnel.externalHost"] = getTunnelURL(actionCtx)
 	actionCtx.Task.Configuration["secretConfig.integration.connectivityService.secretName"] = "connectivity-proxy-service-key"
 	actionCtx.Task.Configuration["config.servers.businessDataTunnel.externalPort"] = "443"
 	actionCtx.Task.Configuration["config.serviceMappings.configMapName"] = mappingsConfigMap

--- a/pkg/reconciler/instances/connectivityproxy/action.go
+++ b/pkg/reconciler/instances/connectivityproxy/action.go
@@ -42,7 +42,7 @@ func (a *CustomAction) Run(context *service.ActionContext) error {
 	if host == "" {
 		return errors.Errorf("Host cannot be empty")
 	}
-	context.Task.Configuration["global.kubeHost"] = strings.TrimPrefix(host, "https://")
+	context.Task.Configuration["global.kubeHost"] = strings.TrimPrefix(host, "https://api.")
 
 	if context.Task.Type == model.OperationTypeDelete {
 		context.Logger.Debug("Requested cluster removal - removing component")
@@ -156,7 +156,6 @@ func (a *CustomAction) Run(context *service.ActionContext) error {
 
 func getTunnelURL(actionCtx *service.ActionContext) string {
 	xtHost := actionCtx.Task.Configuration[tagHost].(string)
-	xtHost = strings.TrimPrefix(xtHost, "api.")
 
 	return fmt.Sprintf("cp.%s", xtHost)
 }

--- a/pkg/reconciler/instances/connectivityproxy/action_test.go
+++ b/pkg/reconciler/instances/connectivityproxy/action_test.go
@@ -37,6 +37,7 @@ func setupActionTestEnv() (*kubeMocks.Client, *service.ActionContext, connectivi
 		Task: &reconciler.Task{
 			Component: "test-component",
 			Configuration: map[string]interface{}{
+				"global.kubeHost":         "api.example.com",
 				"global.binding.url":      "cf.test-address.sap.com",
 				"global.binding.CAs_path": "/api/v1/CAs/signing",
 			},
@@ -71,7 +72,7 @@ func TestAction(t *testing.T) {
 
 		kubeClient, context, action, loader, commands := setupActionTestEnv()
 
-		kubeClient.On("GetHost").Return("test host")
+		kubeClient.On("GetHost").Return("api.example.com")
 		kubeClient.On("GetStatefulSet", context.Context, "test-component", "").Return(nil, nil)
 
 		loader.On("FindBindingOperator", context).Return(binding, nil)
@@ -95,7 +96,7 @@ func TestAction(t *testing.T) {
 
 		kubeClient, context, action, loader, commands := setupActionTestEnv()
 
-		kubeClient.On("GetHost").Return("test host")
+		kubeClient.On("GetHost").Return("api.example.com")
 		kubeClient.On("GetStatefulSet", context.Context, "test-component", "").Return(statefulset, nil)
 		loader.On("FindBindingOperator", context).Return(nil, nil)
 
@@ -112,7 +113,7 @@ func TestAction(t *testing.T) {
 	t.Run("Should refresh app when both binding and app exists", func(t *testing.T) {
 		kubeClient, context, action, loader, commands := setupActionTestEnv()
 
-		kubeClient.On("GetHost").Return("test host")
+		kubeClient.On("GetHost").Return("api.example.com")
 		kubeClient.On("GetStatefulSet", context.Context, "test-component", "").Return(statefulset, nil)
 
 		commands.On("CreateSecretMappingOperator", context, "kyma-system").Return([]byte("testme"), nil)
@@ -135,7 +136,7 @@ func TestAction(t *testing.T) {
 	t.Run("Should do nothing when binding and app are missing ", func(t *testing.T) {
 		kubeClient, context, action, loader, commands := setupActionTestEnv()
 
-		kubeClient.On("GetHost").Return("test host")
+		kubeClient.On("GetHost").Return("api.example.com")
 		kubeClient.On("GetStatefulSet", context.Context, "test-component", "").Return(nil, nil)
 
 		loader.On("FindBindingOperator", context).Return(nil, nil)
@@ -151,7 +152,7 @@ func TestAction(t *testing.T) {
 	t.Run("Should ignore error when binding exists, and FindSecret returns error", func(t *testing.T) {
 		kubeClient, context, action, loader, commands := setupActionTestEnv()
 
-		kubeClient.On("GetHost").Return("test host")
+		kubeClient.On("GetHost").Return("api.example.com")
 		kubeClient.On("GetStatefulSet", context.Context, "test-component", "").Return(nil, nil)
 
 		loader.On("FindBindingOperator", context).Return(binding, nil)
@@ -177,7 +178,7 @@ func TestAction(t *testing.T) {
 
 		kubeClient, context, action, loader, commands := setupActionTestEnv()
 
-		kubeClient.On("GetHost").Return("test host")
+		kubeClient.On("GetHost").Return("api.example.com")
 		kubeClient.On("GetStatefulSet", context.Context, "test-component", "").Return(statefulset, nil)
 
 		commands.On("CreateSecretMappingOperator", context, "kyma-system").Return([]byte("testme"), nil)
@@ -189,7 +190,7 @@ func TestAction(t *testing.T) {
 		commands.On("CreateCARootSecret", context, mock.AnythingOfType("*connectivityclient.ConnectivityCAClient")).Return(nil)
 		commands.On("Apply", context, true).Return(nil)
 		commands.On("CreateSecretCpSvcKey", context, "kyma-system", "connectivity-proxy-service-key", mock.Anything).Return(nil)
-		commands.On("FixConfiguration", context, "kyma-system", "connectivity-proxy").Return(nil)
+		commands.On("FixConfiguration", context, "kyma-system", "connectivity-proxy", "cp.example.com").Return(nil)
 
 		err := action.Run(context)
 		require.NoError(t, err)

--- a/pkg/reconciler/instances/connectivityproxy/action_test.go
+++ b/pkg/reconciler/instances/connectivityproxy/action_test.go
@@ -37,7 +37,6 @@ func setupActionTestEnv() (*kubeMocks.Client, *service.ActionContext, connectivi
 		Task: &reconciler.Task{
 			Component: "test-component",
 			Configuration: map[string]interface{}{
-				"global.kubeHost":         "api.example.com",
 				"global.binding.url":      "cf.test-address.sap.com",
 				"global.binding.CAs_path": "/api/v1/CAs/signing",
 			},
@@ -72,7 +71,7 @@ func TestAction(t *testing.T) {
 
 		kubeClient, context, action, loader, commands := setupActionTestEnv()
 
-		kubeClient.On("GetHost").Return("api.example.com")
+		kubeClient.On("GetHost").Return("https://api.example.com")
 		kubeClient.On("GetStatefulSet", context.Context, "test-component", "").Return(nil, nil)
 
 		loader.On("FindBindingOperator", context).Return(binding, nil)
@@ -96,7 +95,7 @@ func TestAction(t *testing.T) {
 
 		kubeClient, context, action, loader, commands := setupActionTestEnv()
 
-		kubeClient.On("GetHost").Return("api.example.com")
+		kubeClient.On("GetHost").Return("https://api.example.com")
 		kubeClient.On("GetStatefulSet", context.Context, "test-component", "").Return(statefulset, nil)
 		loader.On("FindBindingOperator", context).Return(nil, nil)
 
@@ -113,7 +112,7 @@ func TestAction(t *testing.T) {
 	t.Run("Should refresh app when both binding and app exists", func(t *testing.T) {
 		kubeClient, context, action, loader, commands := setupActionTestEnv()
 
-		kubeClient.On("GetHost").Return("api.example.com")
+		kubeClient.On("GetHost").Return("https://api.example.com")
 		kubeClient.On("GetStatefulSet", context.Context, "test-component", "").Return(statefulset, nil)
 
 		commands.On("CreateSecretMappingOperator", context, "kyma-system").Return([]byte("testme"), nil)
@@ -136,7 +135,7 @@ func TestAction(t *testing.T) {
 	t.Run("Should do nothing when binding and app are missing ", func(t *testing.T) {
 		kubeClient, context, action, loader, commands := setupActionTestEnv()
 
-		kubeClient.On("GetHost").Return("api.example.com")
+		kubeClient.On("GetHost").Return("https://api.example.com")
 		kubeClient.On("GetStatefulSet", context.Context, "test-component", "").Return(nil, nil)
 
 		loader.On("FindBindingOperator", context).Return(nil, nil)
@@ -152,7 +151,7 @@ func TestAction(t *testing.T) {
 	t.Run("Should ignore error when binding exists, and FindSecret returns error", func(t *testing.T) {
 		kubeClient, context, action, loader, commands := setupActionTestEnv()
 
-		kubeClient.On("GetHost").Return("api.example.com")
+		kubeClient.On("GetHost").Return("https://api.example.com")
 		kubeClient.On("GetStatefulSet", context.Context, "test-component", "").Return(nil, nil)
 
 		loader.On("FindBindingOperator", context).Return(binding, nil)
@@ -178,7 +177,7 @@ func TestAction(t *testing.T) {
 
 		kubeClient, context, action, loader, commands := setupActionTestEnv()
 
-		kubeClient.On("GetHost").Return("api.example.com")
+		kubeClient.On("GetHost").Return("https://api.example.com")
 		kubeClient.On("GetStatefulSet", context.Context, "test-component", "").Return(statefulset, nil)
 
 		commands.On("CreateSecretMappingOperator", context, "kyma-system").Return([]byte("testme"), nil)

--- a/pkg/reconciler/instances/connectivityproxy/command.go
+++ b/pkg/reconciler/instances/connectivityproxy/command.go
@@ -35,7 +35,7 @@ type Commands interface {
 	CreateSecretCpSvcKey(ctx *service.ActionContext, ns, secretName, cpSvcKey string) error
 	Remove(*service.ActionContext) error
 	CreateServiceMappingConfigMap(ctx *service.ActionContext, ns, configMapName string) error
-	FixConfiguration(ctx *service.ActionContext, ns, name string) error
+	FixConfiguration(ctx *service.ActionContext, ns, name, tunnelURL string) error
 }
 
 type CommandActions struct {
@@ -324,11 +324,11 @@ func (a *CommandActions) CreateServiceMappingConfigMap(svcActionCtx *service.Act
 
 // FixConfiguration function corrects the config map to make sure certificate domain, and Connectivity Proxy's configuration match.
 // This is 2.9.2 specific.
-func (a *CommandActions) FixConfiguration(ctx *service.ActionContext, ns, name string) error {
+func (a *CommandActions) FixConfiguration(ctx *service.ActionContext, ns, name, tunnelURL string) error {
 	clientset, err := ctx.KubeClient.Clientset()
 	if err != nil {
 		return errors.Wrap(err, "cannot get a target cluster client set")
 	}
 
-	return configmaps.NewConfigMapRepo(ns, clientset).FixConfiguration(ns, name)
+	return configmaps.NewConfigMapRepo(ns, clientset).FixConfiguration(ns, name, tunnelURL)
 }

--- a/pkg/reconciler/instances/connectivityproxy/configmaps/repository.go
+++ b/pkg/reconciler/instances/connectivityproxy/configmaps/repository.go
@@ -3,11 +3,11 @@ package configmaps
 import (
 	"context"
 	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
 	coreV1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8s "k8s.io/client-go/kubernetes"
-	"strings"
 )
 
 const (
@@ -70,9 +70,9 @@ func (cmr ConfigMapRepo) createConfigMap(ctx context.Context, cm *coreV1.ConfigM
 	return err
 }
 
-// FixConfiguration function corrects the exposed channel's url. Previous versions used cc-proxy prefix, and now we use cp prefix.
+// FixConfiguration function corrects the exposed channel's url. Previous versions used cc-proxy.api prefix, and now we use cp prefix.
 // This is 2.9.2 specific.
-func (cmr ConfigMapRepo) FixConfiguration(namespace, name string) error {
+func (cmr ConfigMapRepo) FixConfiguration(namespace, name, tunnelURL string) error {
 	configMap, err := cmr.TargetClientSet.CoreV1().ConfigMaps(namespace).Get(context.Background(), name, v1.GetOptions{})
 	if err != nil && k8serrors.IsNotFound(err) {
 		// ConfigMap is not created yet, nothing to do
@@ -83,15 +83,9 @@ func (cmr ConfigMapRepo) FixConfiguration(namespace, name string) error {
 		return errors.Wrap(err, "cannot get config map")
 	}
 
-	config, ok := configMap.Data[configurationKey]
-	if !ok {
-		return errors.New("cannot find configuration key in the config map")
-	}
-
-	newConfig := strings.Replace(config, "externalHost: cc-proxy.", "externalHost: cp.", -1)
-	if newConfig == config {
-		// Already replaced, nothing to do
-		return nil
+	err = fixYamlConfig(configMap.Data, tunnelURL)
+	if err != nil {
+		return err
 	}
 
 	labels := configMap.GetLabels()
@@ -101,11 +95,112 @@ func (cmr ConfigMapRepo) FixConfiguration(namespace, name string) error {
 
 	labels[restartLabel] = connectivityProxyService
 
-	configMap.Data[configurationKey] = newConfig
 	_, err = cmr.TargetClientSet.CoreV1().ConfigMaps(namespace).Update(context.Background(), configMap, v1.UpdateOptions{})
 	if err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func fixYamlConfig(configMapData map[string]string, tunnelURL string) error {
+	config, ok := configMapData[configurationKey]
+	if !ok {
+		return errors.New("cannot find configuration key in the config map")
+	}
+
+	configYaml, err := readYaml(config)
+	if err != nil {
+		return err
+	}
+
+	currentTunnelURL, err := getTunnelURL(configYaml)
+	if err != nil {
+		return err
+	}
+
+	if currentTunnelURL == tunnelURL {
+		return nil
+	}
+
+	err = replaceTunnelURL(configYaml, tunnelURL)
+	if err != nil {
+		return err
+	}
+
+	modifiedYaml, err := writeYaml(configYaml)
+	if err != nil {
+		return err
+	}
+
+	configMapData[configurationKey] = modifiedYaml
+
+	return nil
+}
+
+func readYaml(config string) (map[string]interface{}, error) {
+	data := make(map[string]interface{})
+	err := yaml.Unmarshal([]byte(config), &data)
+	if err != nil {
+		return map[string]interface{}{}, err
+	}
+
+	return data, err
+}
+
+func writeYaml(configMap map[string]interface{}) (string, error) {
+	yamlBytes, err := yaml.Marshal(&configMap)
+	if err != nil {
+		return "", err
+	}
+	return string(yamlBytes), nil
+}
+
+func getTunnelURL(config map[string]interface{}) (string, error) {
+	businessDataTunnelMap, err := getTunnelConfig(config)
+	if err != nil {
+		return "", err
+	}
+
+	externalHost, ok := businessDataTunnelMap["externalHost"].(string)
+	if !ok {
+		return "", errors.New("servers key type must be string")
+	}
+
+	return externalHost, nil
+}
+
+func replaceTunnelURL(config map[string]interface{}, tunnelURL string) error {
+	businessDataTunnelMap, err := getTunnelConfig(config)
+	if err != nil {
+		return err
+	}
+
+	businessDataTunnelMap["externalHost"] = tunnelURL
+
+	return nil
+}
+
+func getTunnelConfig(config map[string]interface{}) (map[string]interface{}, error) {
+	servers, ok := config["servers"]
+	if !ok {
+		return map[string]interface{}{}, errors.New("failed to find servers key in config")
+	}
+
+	serversMap, ok := servers.(map[string]interface{})
+	if !ok {
+		return map[string]interface{}{}, errors.New("servers key type must be map[string]interface{}")
+	}
+
+	businessDataTunnel, ok := serversMap["businessDataTunnel"]
+	if !ok {
+		return map[string]interface{}{}, errors.New("failed to find businessDataTunnel key in config")
+	}
+
+	businessDataTunnelMap, ok := businessDataTunnel.(map[string]interface{})
+	if !ok {
+		return map[string]interface{}{}, errors.New("businessDataTunnel key type must be map[string]interface{}")
+	}
+
+	return businessDataTunnelMap, nil
 }

--- a/pkg/reconciler/instances/connectivityproxy/mocks/commands.go
+++ b/pkg/reconciler/instances/connectivityproxy/mocks/commands.go
@@ -97,13 +97,13 @@ func (_m *Commands) CreateServiceMappingConfigMap(ctx *service.ActionContext, ns
 	return r0
 }
 
-// PatchConfigMap provides a mock function with given fields: ctx, ns, name
-func (_m *Commands) FixConfiguration(ctx *service.ActionContext, ns string, name string) error {
-	ret := _m.Called(ctx, ns, name)
+// FixConfiguration provides a mock function with given fields: ctx, ns, name, tunnelURL
+func (_m *Commands) FixConfiguration(ctx *service.ActionContext, ns string, name string, tunnelURL string) error {
+	ret := _m.Called(ctx, ns, name, tunnelURL)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*service.ActionContext, string, string) error); ok {
-		r0 = rf(ctx, ns, name)
+	if rf, ok := ret.Get(0).(func(*service.ActionContext, string, string, string) error); ok {
+		r0 = rf(ctx, ns, name, tunnelURL)
 	} else {
 		r0 = ret.Error(0)
 	}


### PR DESCRIPTION
Gardener no longer allows to create certificate for API server subdomains. So if the dns name is of form cp.api.myserver.com, and api.myserver.com is API server domain, Gardener will fail to create a certificate. 
This PR contains the following changes:
- Changing Connectivity Proxy's tunnel address to not contain api prefix
- Fixing configuration for existent clusters