### PR TITLE
Skip components by env-var

### DIFF
--- a/pkg/model/clusterconfigentity.go
+++ b/pkg/model/clusterconfigentity.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
+	"os"
 	"reflect"
 	"strings"
 	"time"
@@ -173,7 +174,13 @@ func (c *ClusterConfigurationEntity) nonMigratedComponents(cfg *ReconciliationSe
 
 	var result []*keb.Component
 	for _, comp := range c.Components {
+		//ignore all migrated components
 		if migratedComponents[strings.ToLower(comp.Component)] {
+			continue
+		}
+		//ignore component if the SKIP_COMPONENT_XYZ env-var is defined
+		skipComp := os.Getenv(fmt.Sprintf("SKIP_COMPONENT_%s", strings.ToUpper(comp.Component)))
+		if strings.ToLower(skipComp) == "true" || skipComp == "1" {
 			continue
 		}
 		result = append(result, comp)

--- a/pkg/model/clusterconfigentity.go
+++ b/pkg/model/clusterconfigentity.go
@@ -182,7 +182,7 @@ func (c *ClusterConfigurationEntity) nonMigratedComponents(cfg *ReconciliationSe
 		envVar := fmt.Sprintf("SKIP_COMPONENT_%s", strings.ReplaceAll(strings.ToUpper(comp.Component), "-", "_"))
 		skipComp := os.Getenv(envVar)
 		if strings.ToLower(skipComp) == "true" || skipComp == "1" {
-			logger.Info("Skipping component %s (env-var: %s = $s)", comp.Component, envVar, skipComp)
+			logger.Infof("Skipping component %s (env-var: %s = %s)", comp.Component, envVar, skipComp)
 			continue
 		}
 		result = append(result, comp)

--- a/pkg/model/clusterconfigentity.go
+++ b/pkg/model/clusterconfigentity.go
@@ -179,7 +179,7 @@ func (c *ClusterConfigurationEntity) nonMigratedComponents(cfg *ReconciliationSe
 			continue
 		}
 		//ignore component if the SKIP_COMPONENT_XYZ env-var is defined
-		envVar := fmt.Sprintf("SKIP_COMPONENT_%s", strings.ToUpper(comp.Component))
+		envVar := fmt.Sprintf("SKIP_COMPONENT_%s", strings.ReplaceAll(strings.ToUpper(comp.Component), "-", "_"))
 		skipComp := os.Getenv(envVar)
 		if strings.ToLower(skipComp) == "true" || skipComp == "1" {
 			logger.Info("Skipping component %s (%s = $s)", comp.Component, envVar, skipComp)

--- a/pkg/model/clusterconfigentity.go
+++ b/pkg/model/clusterconfigentity.go
@@ -179,8 +179,10 @@ func (c *ClusterConfigurationEntity) nonMigratedComponents(cfg *ReconciliationSe
 			continue
 		}
 		//ignore component if the SKIP_COMPONENT_XYZ env-var is defined
-		skipComp := os.Getenv(fmt.Sprintf("SKIP_COMPONENT_%s", strings.ToUpper(comp.Component)))
+		envVar := fmt.Sprintf("SKIP_COMPONENT_%s", strings.ToUpper(comp.Component))
+		skipComp := os.Getenv(envVar)
 		if strings.ToLower(skipComp) == "true" || skipComp == "1" {
+			logger.Info("Skipping component %s (%s = $s)", comp.Component, envVar, skipComp)
 			continue
 		}
 		result = append(result, comp)

--- a/pkg/model/clusterconfigentity.go
+++ b/pkg/model/clusterconfigentity.go
@@ -182,7 +182,7 @@ func (c *ClusterConfigurationEntity) nonMigratedComponents(cfg *ReconciliationSe
 		envVar := fmt.Sprintf("SKIP_COMPONENT_%s", strings.ReplaceAll(strings.ToUpper(comp.Component), "-", "_"))
 		skipComp := os.Getenv(envVar)
 		if strings.ToLower(skipComp) == "true" || skipComp == "1" {
-			logger.Info("Skipping component %s (%s = $s)", comp.Component, envVar, skipComp)
+			logger.Info("Skipping component %s (evn-var: %s = $s)", comp.Component, envVar, skipComp)
 			continue
 		}
 		result = append(result, comp)

--- a/pkg/model/clusterconfigentity.go
+++ b/pkg/model/clusterconfigentity.go
@@ -182,7 +182,7 @@ func (c *ClusterConfigurationEntity) nonMigratedComponents(cfg *ReconciliationSe
 		envVar := fmt.Sprintf("SKIP_COMPONENT_%s", strings.ReplaceAll(strings.ToUpper(comp.Component), "-", "_"))
 		skipComp := os.Getenv(envVar)
 		if strings.ToLower(skipComp) == "true" || skipComp == "1" {
-			logger.Info("Skipping component %s (evn-var: %s = $s)", comp.Component, envVar, skipComp)
+			logger.Info("Skipping component %s (env-var: %s = $s)", comp.Component, envVar, skipComp)
 			continue
 		}
 		result = append(result, comp)


### PR DESCRIPTION
Required for migrating components being in the OSS component list, like telemetry or serverless

Configurable via https://github.com/kyma-project/control-plane/pull/2933