### PR TITLE
Hydra migration

### DIFF
--- a/pkg/reconciler/instances/ory/action.go
+++ b/pkg/reconciler/instances/ory/action.go
@@ -47,7 +47,7 @@ type postDeleteAction struct {
 }
 
 const (
-	databaseSecretName = "ory-hydra-credentials"
+	hydraDbResourceName = "ory-hydra-credentials"
 )
 
 var (
@@ -63,10 +63,10 @@ func getDatabaseNamespacedName(ctx context.Context, client kubernetes.Interface)
 	}
 
 	if deprecatedNamespaceExists {
-		return types.NamespacedName{Name: databaseSecretName, Namespace: deprecation.Namespace}, nil
+		return types.NamespacedName{Name: hydraDbResourceName, Namespace: deprecation.Namespace}, nil
 	}
 
-	return types.NamespacedName{Name: databaseSecretName, Namespace: oryNamespace}, nil
+	return types.NamespacedName{Name: hydraDbResourceName, Namespace: oryNamespace}, nil
 }
 
 func (a *postReconcileAction) Run(context *service.ActionContext) error {
@@ -113,9 +113,6 @@ func (a *preReconcileAction) Run(context *service.ActionContext) error {
 		return errors.Wrap(err, "Failed to retrieve clientset")
 	}
 
-	if err != nil {
-		return errors.Wrap(err, "Failed to get JWKS secret name")
-	}
 	_, err = getSecret(context.Context, client, jwksNamespacedName)
 	if err != nil {
 		if !kerrors.IsNotFound(err) {

--- a/pkg/reconciler/instances/ory/action_test.go
+++ b/pkg/reconciler/instances/ory/action_test.go
@@ -278,7 +278,7 @@ func Test_PreInstallAction_Run(t *testing.T) {
 		require.Equal(t, jwksNamespacedName.Namespace, secret.Namespace)
 		require.NotEmpty(t, secret.Data)
 
-		secret, err = clientSet.CoreV1().Secrets(oryNamespace).Get(actionContext.Context, databaseSecretName, metav1.GetOptions{})
+		secret, err = clientSet.CoreV1().Secrets(oryNamespace).Get(actionContext.Context, hydraDbResourceName, metav1.GetOptions{})
 		require.Error(t, err)
 		require.True(t, kerrors.IsNotFound(err))
 	})
@@ -307,7 +307,7 @@ func Test_PreInstallAction_Run(t *testing.T) {
 		require.Equal(t, jwksNamespacedName.Namespace, secret.Namespace)
 		require.NotEmpty(t, secret.Data)
 
-		secret, err = clientSet.CoreV1().Secrets(oryNamespace).Get(actionContext.Context, databaseSecretName, metav1.GetOptions{})
+		secret, err = clientSet.CoreV1().Secrets(oryNamespace).Get(actionContext.Context, hydraDbResourceName, metav1.GetOptions{})
 		require.Error(t, err)
 		require.True(t, kerrors.IsNotFound(err))
 	})
@@ -404,9 +404,9 @@ func Test_PreInstallAction_Run(t *testing.T) {
 		require.NoError(t, err)
 		provider.AssertCalled(t, "Configuration", mock.AnythingOfType("*chart.Component"))
 		kubeClient.AssertCalled(t, "Clientset")
-		secret, err := clientSet.CoreV1().Secrets(oryNamespace).Get(actionContext.Context, databaseSecretName, metav1.GetOptions{})
+		secret, err := clientSet.CoreV1().Secrets(oryNamespace).Get(actionContext.Context, hydraDbResourceName, metav1.GetOptions{})
 		require.NoError(t, err)
-		require.Equal(t, databaseSecretName, secret.Name)
+		require.Equal(t, hydraDbResourceName, secret.Name)
 		require.Equal(t, oryNamespace, secret.Namespace)
 		require.Equal(t, inMemoryURL, secret.StringData["dsn"])
 	})
@@ -437,9 +437,9 @@ func Test_PreInstallAction_Run(t *testing.T) {
 		require.NoError(t, err)
 		provider.AssertCalled(t, "Configuration", mock.AnythingOfType("*chart.Component"))
 		kubeClient.AssertCalled(t, "Clientset")
-		secret, err := clientSet.CoreV1().Secrets(deprecation.Namespace).Get(actionContext.Context, databaseSecretName, metav1.GetOptions{})
+		secret, err := clientSet.CoreV1().Secrets(deprecation.Namespace).Get(actionContext.Context, hydraDbResourceName, metav1.GetOptions{})
 		require.NoError(t, err)
-		require.Equal(t, databaseSecretName, secret.Name)
+		require.Equal(t, hydraDbResourceName, secret.Name)
 		require.Equal(t, deprecation.Namespace, secret.Namespace)
 		require.Contains(t, secret.StringData["dsn"], "ory-postgresql.hydra-deprecated.svc.cluster.local:5432")
 	})
@@ -464,9 +464,9 @@ func Test_PreInstallAction_Run(t *testing.T) {
 		require.NoError(t, err)
 		provider.AssertCalled(t, "Configuration", mock.AnythingOfType("*chart.Component"))
 		kubeClient.AssertCalled(t, "Clientset")
-		secret, err := clientSet.CoreV1().Secrets(oryNamespace).Get(actionContext.Context, databaseSecretName, metav1.GetOptions{})
+		secret, err := clientSet.CoreV1().Secrets(oryNamespace).Get(actionContext.Context, hydraDbResourceName, metav1.GetOptions{})
 		require.NoError(t, err)
-		require.Equal(t, databaseSecretName, secret.Name)
+		require.Equal(t, hydraDbResourceName, secret.Name)
 		require.Equal(t, oryNamespace, secret.Namespace)
 		require.Equal(t, "", secret.StringData["dsn"])
 		require.Equal(t, []byte(inMemoryURL), secret.Data["dsn"])
@@ -495,9 +495,9 @@ func Test_PreInstallAction_Run(t *testing.T) {
 		require.NoError(t, err)
 		provider.AssertCalled(t, "Configuration", mock.AnythingOfType("*chart.Component"))
 		kubeClient.AssertCalled(t, "Clientset")
-		secret, err := clientSet.CoreV1().Secrets(oryNamespace).Get(actionContext.Context, databaseSecretName, metav1.GetOptions{})
+		secret, err := clientSet.CoreV1().Secrets(oryNamespace).Get(actionContext.Context, hydraDbResourceName, metav1.GetOptions{})
 		require.NoError(t, err)
-		require.Equal(t, databaseSecretName, secret.Name)
+		require.Equal(t, hydraDbResourceName, secret.Name)
 		require.Equal(t, oryNamespace, secret.Namespace)
 		require.Contains(t, secret.StringData["dsn"], "postgres")
 		require.NotContains(t, secret.StringData["dsn"], inMemoryURL)
@@ -595,7 +595,7 @@ func Test_PostDeleteAction_Run(t *testing.T) {
 		clientSet := fake.NewSimpleClientset(existingSecret)
 		kubeClient := newFakeKubeClient(clientSet)
 		actionContext := newFakeServiceContext(&factory, &provider, kubeClient)
-		_, err = clientSet.CoreV1().Secrets(oryNamespace).Get(actionContext.Context, databaseSecretName, metav1.GetOptions{})
+		_, err = clientSet.CoreV1().Secrets(oryNamespace).Get(actionContext.Context, hydraDbResourceName, metav1.GetOptions{})
 		require.False(t, kerrors.IsNotFound(err))
 		action := postDeleteAction{&oryAction{step: "post-delete"}, &oryFinalizersMock}
 
@@ -606,7 +606,7 @@ func Test_PostDeleteAction_Run(t *testing.T) {
 		require.NoError(t, err)
 		kubeClient.AssertCalled(t, "Clientset")
 		kubeClient.AssertCalled(t, "Kubeconfig")
-		_, err = clientSet.CoreV1().Secrets(oryNamespace).Get(actionContext.Context, databaseSecretName, metav1.GetOptions{})
+		_, err = clientSet.CoreV1().Secrets(oryNamespace).Get(actionContext.Context, hydraDbResourceName, metav1.GetOptions{})
 		require.True(t, kerrors.IsNotFound(err))
 	})
 
@@ -635,7 +635,7 @@ func Test_PostDeleteAction_Run(t *testing.T) {
 		require.NoError(t, err)
 		kubeClient.AssertCalled(t, "Clientset")
 		kubeClient.AssertCalled(t, "Kubeconfig")
-		_, err = clientSet.CoreV1().Secrets(oryNamespace).Get(actionContext.Context, databaseSecretName, metav1.GetOptions{})
+		_, err = clientSet.CoreV1().Secrets(oryNamespace).Get(actionContext.Context, hydraDbResourceName, metav1.GetOptions{})
 		require.NoError(t, err)
 	})
 
@@ -664,7 +664,7 @@ func Test_PostDeleteAction_Run(t *testing.T) {
 		require.NoError(t, err)
 		kubeClient.AssertCalled(t, "Clientset")
 		kubeClient.AssertCalled(t, "Kubeconfig")
-		_, err = clientSet.CoreV1().Secrets(oryNamespace).Get(actionContext.Context, databaseSecretName, metav1.GetOptions{})
+		_, err = clientSet.CoreV1().Secrets(oryNamespace).Get(actionContext.Context, hydraDbResourceName, metav1.GetOptions{})
 		require.NoError(t, err)
 	})
 }
@@ -835,7 +835,7 @@ func newFakeServiceContext(factory chart.Factory, provider chart.Provider, clien
 func fixSecretMemory() *v1.Secret {
 	secret := v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      databaseSecretName,
+			Name:      hydraDbResourceName,
 			Namespace: oryNamespace,
 		},
 		Data: map[string][]byte{

--- a/pkg/reconciler/instances/ory/db/db.go
+++ b/pkg/reconciler/instances/ory/db/db.go
@@ -1,8 +1,11 @@
 package db
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"github.com/kyma-incubator/reconciler/pkg/reconciler/instances/ory/deprecation"
+	"k8s.io/client-go/kubernetes"
 
 	"fmt"
 
@@ -15,14 +18,29 @@ import (
 )
 
 const (
-	dsnOpts         = "sslmode=disable&max_conn_lifetime=10s"
-	mysqlDsnOpts    = "parseTime=true&max_conn_lifetime=10s"
-	dsnTemplate     = "%s://%s:%s@%s/%s?%s"
-	postgresURL     = "ory-postgresql.kyma-system.svc.cluster.local:5432"
-	inMemoryURL     = "sqlite://file::memory:?cache=shared&busy_timeout=5000&_fk=true"
-	disclaimerKey   = "reconciler.kyma-project.io/managed-by-reconciler-disclaimer"
-	disclaimerValue = "DO NOT EDIT - This resource is managed by Kyma.\nAny modifications are discarded and the resource is reverted to the original state."
+	dsnOpts                    = "sslmode=disable&max_conn_lifetime=10s"
+	mysqlDsnOpts               = "parseTime=true&max_conn_lifetime=10s"
+	dsnTemplate                = "%s://%s:%s@%s/%s?%s"
+	postgresURL                = "ory-postgresql.kyma-system.svc.cluster.local:5432"
+	hydraDeprecatedPostgresURL = "ory-postgresql.hydra-deprecated.svc.cluster.local:5432"
+	inMemoryURL                = "sqlite://file::memory:?cache=shared&busy_timeout=5000&_fk=true"
+	disclaimerKey              = "reconciler.kyma-project.io/managed-by-reconciler-disclaimer"
+	disclaimerValue            = "DO NOT EDIT - This resource is managed by Kyma.\nAny modifications are discarded and the resource is reverted to the original state."
 )
+
+func getPostgresUrl(ctx context.Context, client kubernetes.Interface) (string, error) {
+
+	deprecatedNamespaceExists, err := deprecation.NamespaceExists(ctx, client)
+	if err != nil {
+		return "", err
+	}
+
+	if deprecatedNamespaceExists {
+		return hydraDeprecatedPostgresURL, nil
+	}
+
+	return postgresURL, nil
+}
 
 func NewDBConfig(chartValues map[string]interface{}) (*Config, error) {
 	data, err := yaml.Marshal(chartValues)
@@ -39,14 +57,17 @@ func NewDBConfig(chartValues map[string]interface{}) (*Config, error) {
 }
 
 // Get fetches Kubernetes Secret object with data matching the provided Helm values to the Reconciler.
-func Get(name types.NamespacedName, chartValues map[string]interface{}, logger *zap.SugaredLogger) (*v1.Secret, error) {
+func Get(ctx context.Context, client kubernetes.Interface, name types.NamespacedName, chartValues map[string]interface{}, logger *zap.SugaredLogger) (*v1.Secret, error) {
 	logger.Debugf("Fetching secret")
 	cfg, err := NewDBConfig(chartValues)
 	if err != nil {
 		return nil, err
 	}
 
-	data := cfg.prepareStringData()
+	data, err := cfg.prepareStringData(ctx, client)
+	if err != nil {
+		return nil, err
+	}
 
 	return &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -59,7 +80,7 @@ func Get(name types.NamespacedName, chartValues map[string]interface{}, logger *
 }
 
 // Update overwrites secret with new values from config and returns true if secret was changed
-func Update(chartValues map[string]interface{}, secret *v1.Secret, logger *zap.SugaredLogger) (data map[string]string, err error) {
+func Update(ctx context.Context, client kubernetes.Interface, chartValues map[string]interface{}, secret *v1.Secret, logger *zap.SugaredLogger) (data map[string]string, err error) {
 	cfg, err := NewDBConfig(chartValues)
 	if err != nil {
 		return data, err
@@ -75,44 +96,49 @@ func Update(chartValues map[string]interface{}, secret *v1.Secret, logger *zap.S
 		cfg.Global.Ory.Hydra.Persistence.SecretsCookie = generateRandomString(32)
 	}
 
-	data = cfg.updateSecretData(secret, logger)
-	return data, nil
+	return cfg.updateSecretData(ctx, client, secret, logger)
 }
 
-func (c *Config) updateSecretData(secret *v1.Secret, logger *zap.SugaredLogger) map[string]string {
+func (c *Config) updateSecretData(ctx context.Context, client kubernetes.Interface, secret *v1.Secret, logger *zap.SugaredLogger) (map[string]string, error) {
 	data := make(map[string]string)
 	dsn := string(secret.Data["dsn"])
 
 	if !c.Global.Ory.Hydra.Persistence.Enabled {
-		return c.updateMemoryConfig(secret, logger)
+		return c.updateMemoryConfig(secret, logger), nil
 	}
 
 	if c.Global.Ory.Hydra.Persistence.PostgresqlFlag.Enabled {
-		return c.updatePostgresqlConfig(secret, logger)
+		secretData, err := c.updatePostgresqlConfig(ctx, client, secret, logger)
+		if err != nil {
+			return nil, err
+		}
+
+		return secretData, err
+
 	}
 
 	if c.Global.Ory.Hydra.Persistence.DBType == "mysql" {
 		if c.prepareMySQLDSN() != dsn {
 			logger.Debug("Enabling mysql persistence")
-			return c.generateSecretDataMysql()
+			return c.generateSecretDataMysql(), nil
 		}
-		return data
+		return data, nil
 	}
 
 	if c.Global.Ory.Hydra.Persistence.Gcloud.Enabled {
 		if c.prepareGenericDSN() != dsn {
 			logger.Debug("Enabling gcloud persistence")
-			return c.generateSecretDataGcloud()
+			return c.generateSecretDataGcloud(), nil
 		}
-		return data
+		return data, nil
 	}
 
 	if c.prepareGenericDSN() != dsn {
 		logger.Debug("Enabling custom db persistence")
-		return c.generateSecretDataGeneric()
+		return c.generateSecretDataGeneric(), nil
 	}
 
-	return data
+	return data, nil
 }
 
 func (c *Config) updateMemoryConfig(secret *v1.Secret, logger *zap.SugaredLogger) (secretData map[string]string) {
@@ -125,7 +151,7 @@ func (c *Config) updateMemoryConfig(secret *v1.Secret, logger *zap.SugaredLogger
 	return c.generateSecretDataMemory()
 }
 
-func (c *Config) updatePostgresqlConfig(secret *v1.Secret, logger *zap.SugaredLogger) (secretData map[string]string) {
+func (c *Config) updatePostgresqlConfig(ctx context.Context, client kubernetes.Interface, secret *v1.Secret, logger *zap.SugaredLogger) (secretData map[string]string, err error) {
 	secretPostgresqlPassword := string(secret.Data["postgresql-password"])
 	if secretPostgresqlPassword != "" && c.Global.PostgresCfg.Password == "" {
 		c.Global.PostgresCfg.Password = secretPostgresqlPassword
@@ -135,17 +161,31 @@ func (c *Config) updatePostgresqlConfig(secret *v1.Secret, logger *zap.SugaredLo
 		c.Global.PostgresCfg.ReplicationPassword = secretPostgresqlReplicationPassword
 	}
 
-	if c.preparePostgresDSN() != string(secret.Data["dsn"]) {
-		logger.Debug("Enabling postgresql persistence")
-		return c.generateSecretDataPostgresql()
+	postgresDsn, err := c.preparePostgresDSN(ctx, client)
+	if err != nil {
+		return nil, err
 	}
 
-	return secretData
+	if postgresDsn != string(secret.Data["dsn"]) {
+		logger.Debug("Enabling postgresql persistence")
+
+		pgSecretData, err := c.generateSecretDataPostgresql(ctx, client)
+		if err != nil {
+			return nil, err
+		}
+		return pgSecretData, nil
+	}
+
+	return secretData, nil
 }
 
-func (c *Config) preparePostgresDSN() string {
+func (c *Config) preparePostgresDSN(ctx context.Context, client kubernetes.Interface) (string, error) {
+	postgresURL, err := getPostgresUrl(ctx, client)
+	if err != nil {
+		return "", err
+	}
 	return fmt.Sprintf(dsnTemplate, "postgres", c.Global.PostgresCfg.User,
-		c.Global.PostgresCfg.Password, postgresURL, c.Global.PostgresCfg.DBName, dsnOpts)
+		c.Global.PostgresCfg.Password, postgresURL, c.Global.PostgresCfg.DBName, dsnOpts), nil
 }
 
 func (c *Config) prepareMySQLDSN() string {
@@ -161,24 +201,29 @@ func (c *Config) prepareGenericDSN() string {
 		c.Global.Ory.Hydra.Persistence.URL, c.Global.Ory.Hydra.Persistence.DBName, dsnOpts)
 }
 
-func (c *Config) prepareStringData() map[string]string {
+func (c *Config) prepareStringData(ctx context.Context, client kubernetes.Interface) (map[string]string, error) {
 	c.Global.Ory.Hydra.Persistence.SecretsSystem = generateRandomString(32)
 	c.Global.Ory.Hydra.Persistence.SecretsCookie = generateRandomString(32)
 
 	if c.Global.Ory.Hydra.Persistence.Enabled {
 		if c.Global.Ory.Hydra.Persistence.PostgresqlFlag.Enabled {
-			return c.generateSecretDataPostgresql()
+
+			pgSecretData, err := c.generateSecretDataPostgresql(ctx, client)
+			if err != nil {
+				return nil, err
+			}
+			return pgSecretData, nil
 		}
 		if c.Global.Ory.Hydra.Persistence.DBType == "mysql" {
-			return c.generateSecretDataMysql()
+			return c.generateSecretDataMysql(), nil
 		}
 		if c.Global.Ory.Hydra.Persistence.Gcloud.Enabled {
-			return c.generateSecretDataGcloud()
+			return c.generateSecretDataGcloud(), nil
 		}
-		return c.generateSecretDataGeneric()
+		return c.generateSecretDataGeneric(), nil
 	}
 
-	return c.generateSecretDataMemory()
+	return c.generateSecretDataMemory(), nil
 }
 
 func (c *Config) generateSecretDataMemory() map[string]string {
@@ -189,7 +234,7 @@ func (c *Config) generateSecretDataMemory() map[string]string {
 	}
 }
 
-func (c *Config) generateSecretDataPostgresql() map[string]string {
+func (c *Config) generateSecretDataPostgresql(ctx context.Context, client kubernetes.Interface) (map[string]string, error) {
 	if c.Global.PostgresCfg.Password == "" {
 		c.Global.PostgresCfg.Password = generateRandomString(10)
 	}
@@ -198,13 +243,18 @@ func (c *Config) generateSecretDataPostgresql() map[string]string {
 		c.Global.PostgresCfg.ReplicationPassword = generateRandomString(10)
 	}
 
+	postgresDsn, err := c.preparePostgresDSN(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+
 	return map[string]string{
 		"secretsSystem":                   c.Global.Ory.Hydra.Persistence.SecretsSystem,
 		"secretsCookie":                   c.Global.Ory.Hydra.Persistence.SecretsCookie,
-		"dsn":                             c.preparePostgresDSN(),
+		"dsn":                             postgresDsn,
 		"postgresql-password":             c.Global.PostgresCfg.Password,
 		"postgresql-replication-password": c.Global.PostgresCfg.ReplicationPassword,
-	}
+	}, nil
 }
 
 func (c *Config) generateSecretDataMysql() map[string]string {

--- a/pkg/reconciler/instances/ory/db/db.go
+++ b/pkg/reconciler/instances/ory/db/db.go
@@ -28,7 +28,7 @@ const (
 	disclaimerValue            = "DO NOT EDIT - This resource is managed by Kyma.\nAny modifications are discarded and the resource is reverted to the original state."
 )
 
-func getPostgresUrl(ctx context.Context, client kubernetes.Interface) (string, error) {
+func getPostgresURL(ctx context.Context, client kubernetes.Interface) (string, error) {
 
 	deprecatedNamespaceExists, err := deprecation.NamespaceExists(ctx, client)
 	if err != nil {
@@ -180,7 +180,7 @@ func (c *Config) updatePostgresqlConfig(ctx context.Context, client kubernetes.I
 }
 
 func (c *Config) preparePostgresDSN(ctx context.Context, client kubernetes.Interface) (string, error) {
-	postgresURL, err := getPostgresUrl(ctx, client)
+	postgresURL, err := getPostgresURL(ctx, client)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/reconciler/instances/ory/db/db_test.go
+++ b/pkg/reconciler/instances/ory/db/db_test.go
@@ -1,6 +1,8 @@
 package db
 
 import (
+	"context"
+	"k8s.io/client-go/kubernetes/fake"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -97,10 +99,13 @@ func TestDBSecret(t *testing.T) {
 		values, err := unmarshalTestValues(postgresYaml)
 		require.NoError(t, err)
 		cfg, errNew := NewDBConfig(values)
-		dsnExpected := cfg.preparePostgresDSN()
+		ctx := context.TODO()
+		k8sClient := fake.NewSimpleClientset()
+		dsnExpected, err := cfg.preparePostgresDSN(ctx, k8sClient)
+		require.NoError(t, err)
 
 		// when
-		secret, errGet := Get(name, values, logger)
+		secret, errGet := Get(ctx, k8sClient, name, values, logger)
 
 		// then
 		require.NoError(t, errNew)
@@ -118,9 +123,11 @@ func TestDBSecret(t *testing.T) {
 		require.NoError(t, err)
 		cfg, errNew := NewDBConfig(values)
 		dsnExpected := cfg.prepareGenericDSN()
+		ctx := context.TODO()
+		k8sClient := fake.NewSimpleClientset()
 
 		// when
-		secret, errGet := Get(name, values, logger)
+		secret, errGet := Get(ctx, k8sClient, name, values, logger)
 
 		// then
 		require.NoError(t, errNew)
@@ -138,9 +145,11 @@ func TestDBSecret(t *testing.T) {
 		require.NoError(t, err)
 		cfg, errNew := NewDBConfig(values)
 		dsnExpected := cfg.prepareMySQLDSN()
+		ctx := context.TODO()
+		k8sClient := fake.NewSimpleClientset()
 
 		// when
-		secret, errGet := Get(name, values, logger)
+		secret, errGet := Get(ctx, k8sClient, name, values, logger)
 
 		// then
 		require.NoError(t, errNew)
@@ -157,9 +166,11 @@ func TestDBSecret(t *testing.T) {
 		require.NoError(t, err)
 		cfg, errNew := NewDBConfig(values)
 		dsnExpected := cfg.prepareGenericDSN()
+		ctx := context.TODO()
+		k8sClient := fake.NewSimpleClientset()
 
 		// when
-		secret, errGet := Get(name, values, logger)
+		secret, errGet := Get(ctx, k8sClient, name, values, logger)
 
 		// then
 		require.NoError(t, errNew)
@@ -174,9 +185,11 @@ func TestDBSecret(t *testing.T) {
 		name := types.NamespacedName{Name: "test-memory-secret", Namespace: "test"}
 		values, err := unmarshalTestValues(noDBYaml)
 		require.NoError(t, err)
+		ctx := context.TODO()
+		k8sClient := fake.NewSimpleClientset()
 
 		// when
-		secret, err := Get(name, values, logger)
+		secret, err := Get(ctx, k8sClient, name, values, logger)
 
 		// then
 		require.NoError(t, err)
@@ -200,9 +213,11 @@ func TestDBSecretUpdate(t *testing.T) {
 		values, err := unmarshalTestValues(noDBYaml)
 		require.NoError(t, err)
 		oldSecret := fixSecretWithNameDsn("test-memory-secret", inMemoryURL)
+		ctx := context.TODO()
+		k8sClient := fake.NewSimpleClientset()
 
 		// when
-		secretData, errUpdate := Update(values, oldSecret, logger)
+		secretData, errUpdate := Update(ctx, k8sClient, values, oldSecret, logger)
 
 		// then
 		require.NoError(t, errUpdate)
@@ -216,9 +231,11 @@ func TestDBSecretUpdate(t *testing.T) {
 		require.NoError(t, err)
 		oldSecret := fixSecretWithNameDsn("test-postgres-secret",
 			"postgres://hydra:secretpw@ory-postgresql.kyma-system.svc.cluster.local:5432/db4hydra?sslmode=disable&max_conn_lifetime=10s")
+		ctx := context.TODO()
+		k8sClient := fake.NewSimpleClientset()
 
 		// when
-		secretData, errUpdate := Update(values, oldSecret, logger)
+		secretData, errUpdate := Update(ctx, k8sClient, values, oldSecret, logger)
 
 		// then
 		require.NoError(t, errUpdate)
@@ -232,9 +249,11 @@ func TestDBSecretUpdate(t *testing.T) {
 		require.NoError(t, err)
 		oldSecret := fixSecretWithNameDsn("test-postgres-secret",
 			"postgres://hydra:secretpw@ory-gcloud-sqlproxy.kyma-system:5432/db4hydra?sslmode=disable&max_conn_lifetime=10s")
+		ctx := context.TODO()
+		k8sClient := fake.NewSimpleClientset()
 
 		// when
-		secretData, errUpdate := Update(values, oldSecret, logger)
+		secretData, errUpdate := Update(ctx, k8sClient, values, oldSecret, logger)
 
 		// then
 		require.NoError(t, errUpdate)
@@ -248,9 +267,11 @@ func TestDBSecretUpdate(t *testing.T) {
 		require.NoError(t, err)
 		oldSecret := fixSecretWithNameDsn("test-postgres-secret",
 			"mysql://hydra:secretpw@tcp(mydb.mynamespace:1234)/db4hydra?parseTime=true&max_conn_lifetime=10s")
+		ctx := context.TODO()
+		k8sClient := fake.NewSimpleClientset()
 
 		// when
-		secretData, errUpdate := Update(values, oldSecret, logger)
+		secretData, errUpdate := Update(ctx, k8sClient, values, oldSecret, logger)
 
 		// then
 		require.NoError(t, errUpdate)
@@ -264,9 +285,11 @@ func TestDBSecretUpdate(t *testing.T) {
 		require.NoError(t, err)
 		oldSecret := fixSecretWithNameDsn("test-postgres-secret",
 			"cockroach://hydra:secretpw@mydb.mynamespace:1234/db4hydra?sslmode=disable&max_conn_lifetime=10s")
+		ctx := context.TODO()
+		k8sClient := fake.NewSimpleClientset()
 
 		// when
-		secretData, errUpdate := Update(values, oldSecret, logger)
+		secretData, errUpdate := Update(ctx, k8sClient, values, oldSecret, logger)
 
 		// then
 		require.NoError(t, errUpdate)
@@ -279,9 +302,11 @@ func TestDBSecretUpdate(t *testing.T) {
 		values, err := unmarshalTestValues(postgresYaml)
 		require.NoError(t, err)
 		oldSecret := fixSecretWithNameDsn("test-memory-secret", inMemoryURL)
+		ctx := context.TODO()
+		k8sClient := fake.NewSimpleClientset()
 
 		// when
-		secretData, errUpdate := Update(values, oldSecret, logger)
+		secretData, errUpdate := Update(ctx, k8sClient, values, oldSecret, logger)
 
 		// then
 		require.NoError(t, errUpdate)
@@ -296,9 +321,11 @@ func TestDBSecretUpdate(t *testing.T) {
 		values, err := unmarshalTestValues(gcloudYaml)
 		require.NoError(t, err)
 		oldSecret := fixSecretWithNameDsn("test-memory-secret", inMemoryURL)
+		ctx := context.TODO()
+		k8sClient := fake.NewSimpleClientset()
 
 		// when
-		secretData, errUpdate := Update(values, oldSecret, logger)
+		secretData, errUpdate := Update(ctx, k8sClient, values, oldSecret, logger)
 
 		// then
 		require.NoError(t, errUpdate)
@@ -316,9 +343,11 @@ func TestDBSecretUpdate(t *testing.T) {
 		values, err := unmarshalTestValues(mysqlDBYaml)
 		require.NoError(t, err)
 		oldSecret := fixSecretWithNameDsn("test-memory-secret", inMemoryURL)
+		ctx := context.TODO()
+		k8sClient := fake.NewSimpleClientset()
 
 		// when
-		secretData, errUpdate := Update(values, oldSecret, logger)
+		secretData, errUpdate := Update(ctx, k8sClient, values, oldSecret, logger)
 
 		// then
 		require.NoError(t, errUpdate)
@@ -335,9 +364,11 @@ func TestDBSecretUpdate(t *testing.T) {
 		values, err := unmarshalTestValues(customDBYaml)
 		require.NoError(t, err)
 		oldSecret := fixSecretWithNameDsn("test-memory-secret", inMemoryURL)
+		ctx := context.TODO()
+		k8sClient := fake.NewSimpleClientset()
 
 		// when
-		secretData, errUpdate := Update(values, oldSecret, logger)
+		secretData, errUpdate := Update(ctx, k8sClient, values, oldSecret, logger)
 
 		// then
 		require.NoError(t, errUpdate)
@@ -355,9 +386,11 @@ func TestDBSecretUpdate(t *testing.T) {
 		require.NoError(t, err)
 		oldSecret := fixSecretWithNameDsn("test-postgres-secret",
 			"postgres://hydra:pass@ory-postgresql.kyma-system.svc.cluster.local:5432/db4hydra?sslmode=disable&max_conn_lifetime=10s")
+		ctx := context.TODO()
+		k8sClient := fake.NewSimpleClientset()
 
 		// when
-		secretData, errUpdate := Update(values, oldSecret, logger)
+		secretData, errUpdate := Update(ctx, k8sClient, values, oldSecret, logger)
 
 		// then
 		require.NoError(t, errUpdate)
@@ -372,9 +405,11 @@ func TestDBSecretUpdate(t *testing.T) {
 		require.NoError(t, err)
 		oldSecret := fixSecretWithNameDsn("test-postgres-secret",
 			"postgres://hydra:pass@ory-postgresql.kyma-system.svc.cluster.local:5432/db4hydra?sslmode=disable&max_conn_lifetime=10s")
+		ctx := context.TODO()
+		k8sClient := fake.NewSimpleClientset()
 
 		// when
-		secretData, errUpdate := Update(values, oldSecret, logger)
+		secretData, errUpdate := Update(ctx, k8sClient, values, oldSecret, logger)
 
 		// then
 		require.NoError(t, errUpdate)
@@ -392,9 +427,11 @@ func TestDBSecretUpdate(t *testing.T) {
 		require.NoError(t, err)
 		oldSecret := fixSecretWithNameDsn("test-postgres-secret",
 			"postgres://hydra:secretpw@ory-gcloud-sqlproxy.kyma-system:5432/db4hydra?sslmode=disable&max_conn_lifetime=10s")
+		ctx := context.TODO()
+		k8sClient := fake.NewSimpleClientset()
 
 		// when
-		secretData, errUpdate := Update(values, oldSecret, logger)
+		secretData, errUpdate := Update(ctx, k8sClient, values, oldSecret, logger)
 
 		// then
 		require.NoError(t, errUpdate)

--- a/pkg/reconciler/instances/ory/db/model.go
+++ b/pkg/reconciler/instances/ory/db/model.go
@@ -3,6 +3,11 @@ package db
 // Config holds the database configuration values of Ory Hydra.
 type Config struct {
 	Global Global
+	Hydra  *HydraRoot `yaml:"hydra"`
+}
+
+type HydraRoot struct {
+	Enabled *bool `yaml:"enabled"`
 }
 
 // Global configuration of Ory Hydra and PostgresSQL

--- a/pkg/reconciler/instances/ory/deprecation/namespace.go
+++ b/pkg/reconciler/instances/ory/deprecation/namespace.go
@@ -1,0 +1,22 @@
+package deprecation
+
+import (
+	"context"
+	"github.com/pkg/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const Namespace = "hydra-deprecated"
+
+func NamespaceExists(ctx context.Context, client kubernetes.Interface) (bool, error) {
+	_, err := client.CoreV1().Namespaces().Get(ctx, Namespace, metav1.GetOptions{})
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, errors.Wrapf(err, "Could not get %s namespace", Namespace)
+	}
+	return true, nil
+}

--- a/pkg/reconciler/instances/ory/test/ory_integration_test.go
+++ b/pkg/reconciler/instances/ory/test/ory_integration_test.go
@@ -1,16 +1,13 @@
 package test
 
 import (
-	"testing"
-	"time"
-
 	"github.com/stretchr/testify/require"
 	v1apps "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	v1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/kubectl/pkg/util/podutils"
+	"testing"
 )
 
 func TestOryIntegration(t *testing.T) {
@@ -19,32 +16,19 @@ func TestOryIntegration(t *testing.T) {
 	setup := newOryTest(t)
 	defer setup.contextCancel()
 
-	t.Run("ensure that ory pods are deployed and ready", func(t *testing.T) {
+	t.Run("ensure that ory pods are not deployed", func(t *testing.T) {
 		options := metav1.ListOptions{
 			LabelSelector: "app.kubernetes.io/instance=ory",
 		}
-		err := wait.Poll(1*time.Second, 1*time.Minute, func() (done bool, err error) {
-			podsList, err := setup.getPods(options)
-			if err != nil {
-				return false, err
-			}
-			for i := range podsList.Items {
-				setup.logger.Infof("Pod %v is deployed", podsList.Items[i].Name)
-				if !podutils.IsPodAvailable(&podsList.Items[i], 0, metav1.Now()) {
-					setup.logger.Infof("Pod %v is not ready", podsList.Items[i].Name)
-					return false, err
-				}
-			}
-			return true, nil
-		})
+
+		podsList, err := setup.getPods(options)
 		require.NoError(t, err)
-		setup.logger.Info("All Ory pods are deployed and ready")
+		require.Empty(t, podsList.Items)
 	})
 
 	t.Run("ensure that ory secrets are deployed", func(t *testing.T) {
 		jwksName := "ory-oathkeeper-jwks-secret"
 		setup.ensureSecretIsDeployed(t, jwksName)
-		setup.ensureSecretIsDeployed(t, "ory-hydra-credentials")
 	})
 }
 
@@ -58,13 +42,11 @@ func TestOryIntegrationProduction(t *testing.T) {
 	setup := newOryTest(t)
 	defer setup.contextCancel()
 
-	t.Run("ensure that ory-hydra hpa is deployed", func(t *testing.T) {
+	t.Run("ensure that ory-hydra hpa is not deployed", func(t *testing.T) {
 		name := "ory-hydra"
-		hpa, err := setup.getHorizontalPodAutoscaler(name)
-		require.NoError(t, err)
-		require.GreaterOrEqual(t, int32(2), hpa.Status.CurrentReplicas)
-		require.Equal(t, int32(5), hpa.Spec.MaxReplicas)
-		setup.logger.Infof("HorizontalPodAutoscaler %v is deployed", hpa.Name)
+		_, err := setup.getHorizontalPodAutoscaler(name)
+		require.Error(t, err)
+		setup.logger.Infof("HorizontalPodAutoscaler is not deployed")
 	})
 
 	t.Run("ensure that ory-oathkeeper hpa is deployed", func(t *testing.T) {
@@ -76,14 +58,20 @@ func TestOryIntegrationProduction(t *testing.T) {
 		setup.logger.Infof("HorizontalPodAutoscaler %v is deployed", hpa.Name)
 	})
 
-	t.Run("ensure that ory-postgresql is deployed", func(t *testing.T) {
+	t.Run("ensure that ory-postgresql is not deployed", func(t *testing.T) {
 		name := "ory-postgresql"
-		sts, err := setup.getStatefulSet(name)
-		require.NoError(t, err)
+		_, err := setup.getStatefulSet(name)
+		require.Error(t, err)
+		require.True(t, kerrors.IsNotFound(err))
+	})
 
-		require.Equal(t, int32(1), sts.Status.Replicas)
-		require.Equal(t, int32(1), sts.Status.ReadyReplicas)
-		setup.logger.Infof("StatefulSet %v is deployed", sts.Name)
+	t.Run("ensure that ory-hydra pod is not deployed", func(t *testing.T) {
+		options := metav1.ListOptions{
+			LabelSelector: "app.kubernetes.io/name=hydra",
+		}
+		podsList, err := setup.getPods(options)
+		require.NoError(t, err)
+		require.Empty(t, podsList.Items)
 	})
 
 }
@@ -123,15 +111,13 @@ func TestOryIntegrationEvaluation(t *testing.T) {
 		setup.logger.Infof("Single pod %v is deployed for app: oathkeeper", podsList.Items[0].Name)
 	})
 
-	t.Run("ensure that single ory-hydra pod is deployed", func(t *testing.T) {
+	t.Run("ensure that ory-hydra pod is not deployed", func(t *testing.T) {
 		options := metav1.ListOptions{
 			LabelSelector: "app.kubernetes.io/name=hydra",
-			FieldSelector: "status.phase=Running",
 		}
 		podsList, err := setup.getPods(options)
 		require.NoError(t, err)
-		require.Equal(t, 1, len(podsList.Items))
-		setup.logger.Infof("Single pod %v is deployed for app: hydra", podsList.Items[0].Name)
+		require.Empty(t, podsList.Items)
 	})
 }
 


### PR DESCRIPTION
- Skip reconciliation for Hydra resources (e.g. Hydra database secret, Hydra synchronization, Hydra rollout) when Hydra is disabled or does not exist in chart config
- Create Hydra database secret `ory-hydra-credentials` in `hydra-deprecated` namespace if it exist, otherwise use `kyma-system`. The data source name in the secret is set depending on whether the namespace `hydra-deprecated` exists or not.