### PR TITLE
Skip reconcile when Istio CRDs are missing

### DIFF
--- a/pkg/reconciler/instances/connectivityproxy/action.go
+++ b/pkg/reconciler/instances/connectivityproxy/action.go
@@ -45,8 +45,8 @@ func (a *CustomAction) Run(context *service.ActionContext) error {
 	}
 	context.Task.Configuration["global.kubeHost"] = strings.TrimPrefix(host, "https://api.")
 
-	// checking Istio
 	if istioCRDsAreMissing(context) {
+		context.Logger.Warn("Istio CRDs are missing on the the cluster. Skipping reconcilion")
 		return nil
 	}
 

--- a/pkg/reconciler/instances/connectivityproxy/action.go
+++ b/pkg/reconciler/instances/connectivityproxy/action.go
@@ -45,18 +45,18 @@ func (a *CustomAction) Run(context *service.ActionContext) error {
 	}
 	context.Task.Configuration["global.kubeHost"] = strings.TrimPrefix(host, "https://api.")
 
+	// checking Istio
+	context.Logger.Debug("Checking if Istio CRDs are present on the cluster")
+	if istioCRDsAreMissing(context) {
+		return nil
+	}
+
 	if context.Task.Type == model.OperationTypeDelete {
 		context.Logger.Debug("Requested cluster removal - removing component")
 		if err := a.Commands.Remove(context); err != nil {
 			context.Logger.Error("Failed to remove Connectivity Proxy: %v", err)
 			return err
 		}
-		return nil
-	}
-
-	// checking Istio
-	context.Logger.Debug("Checking Istio")
-	if istioCRDsAreMissing(context) {
 		return nil
 	}
 

--- a/pkg/reconciler/instances/connectivityproxy/action.go
+++ b/pkg/reconciler/instances/connectivityproxy/action.go
@@ -46,7 +46,6 @@ func (a *CustomAction) Run(context *service.ActionContext) error {
 	context.Task.Configuration["global.kubeHost"] = strings.TrimPrefix(host, "https://api.")
 
 	// checking Istio
-	context.Logger.Debug("Checking if Istio CRDs are present on the cluster")
 	if istioCRDsAreMissing(context) {
 		return nil
 	}

--- a/pkg/reconciler/instances/connectivityproxy/action.go
+++ b/pkg/reconciler/instances/connectivityproxy/action.go
@@ -46,7 +46,7 @@ func (a *CustomAction) Run(context *service.ActionContext) error {
 	context.Task.Configuration["global.kubeHost"] = strings.TrimPrefix(host, "https://api.")
 
 	if istioCRDsAreMissing(context) {
-		context.Logger.Warn("Istio CRDs are missing on the the cluster. Skipping reconcilion")
+		context.Logger.Warn("Istio CRDs are missing on the the cluster. Skipping reconciliation")
 		return nil
 	}
 
@@ -97,7 +97,7 @@ func (a *CustomAction) Run(context *service.ActionContext) error {
 	context.Logger.Debug("Service Binding Secret check")
 
 	if bindingSecret == nil {
-		context.Logger.Warnf("Skipping reconcilion, %s", err)
+		context.Logger.Warnf("Skipping reconciliation, %s", err)
 		return nil
 	}
 


### PR DESCRIPTION
Issue: https://github.com/kyma-incubator/reconciler/issues/1386

Check in reconciliation action if Istio Virtual Service or Gateway CRDs are missing on the cluster and in such a case skip the reconciliation.
  