### PR TITLE
Upgrade golang:1.21.5-alpine3.19

### DIFF
--- a/Dockerfile.cr
+++ b/Dockerfile.cr
@@ -1,5 +1,5 @@
 # Build image
-FROM golang:1.21.1-alpine3.17 AS build
+FROM golang:1.21.5-alpine3.19 AS build
 
 ENV SRC_DIR=/go/src/github.com/kyma-incubator/reconciler
 COPY . $SRC_DIR

--- a/Dockerfile.mr
+++ b/Dockerfile.mr
@@ -1,5 +1,5 @@
 # Build image
-FROM golang:1.21.1-alpine3.17 AS build
+FROM golang:1.21.5-alpine3.19 AS build
 
 ENV SRC_DIR=/go/src/github.com/kyma-incubator/reconciler
 COPY . $SRC_DIR


### PR DESCRIPTION
Upgrade to golang:1.21.5-alpine3.19 to fix 
- Protecode-MPS/kyma-project_incubator_reconciler_mothership.tar/golang-runtime:1.21.1:BDSA-2023-3396
- Protecode-MPS/kyma-project_incubator_reconciler_mothership.tar/golang-runtime:1.21.1:BDSA-2023-3390