### PR TITLE
chore: Upgrade build image

### DIFF
--- a/Dockerfile.cr
+++ b/Dockerfile.cr
@@ -1,5 +1,5 @@
 # Build image
-FROM golang:1.21.5-alpine3.19 AS build
+FROM golang:1.21.6-alpine3.19 AS build
 
 ENV SRC_DIR=/go/src/github.com/kyma-incubator/reconciler
 COPY . $SRC_DIR

--- a/Dockerfile.mr
+++ b/Dockerfile.mr
@@ -1,5 +1,5 @@
 # Build image
-FROM golang:1.21.5-alpine3.19 AS build
+FROM golang:1.21.6-alpine3.19 AS build
 
 ENV SRC_DIR=/go/src/github.com/kyma-incubator/reconciler
 COPY . $SRC_DIR


### PR DESCRIPTION
Upgrade to golang:1.21.6-alpine3.19 to fix Protecode warnings